### PR TITLE
Add Sentinel-2 land use classification pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,40 @@
 5. `predict.py` で分類結果ラスタを生成します。
 6. `app.py` をStreamlitで実行し、folium地図上で結果を確認できます。
 
+## Sentinel-2 を用いた土地利用分類
+
+`data/` フォルダに以下の Sentinel-2 バンド (`B02`, `B03`, `B04`, `B08`, `B11`) と
+QA バンド(`QA60`)、学習用ラベル(`labels.tif`) を配置します。
+
+```bash
+data/
+├── B02.tif
+├── B03.tif
+├── B04.tif
+├── B08.tif
+├── B11.tif
+├── QA60.tif
+└── labels.tif
+```
+
+### 3. ランドサット・土地利用分類の実行と表示
+
+まず以下のコマンドで分類を実行してラスタを生成します。
+
+```bash
+python src/classification/pipeline.py \
+  --bands data/B02.tif data/B03.tif data/B04.tif data/B08.tif data/B11.tif \
+  --qa data/QA60.tif \
+  --labels data/labels.tif \
+  --output outputs/prediction.tif
+```
+
+生成された `outputs/prediction.tif` を表示するには次のコマンドを実行します。
+
+```bash
+streamlit run src/app.py
+```
+
 This repository contains a minimal example of a Python pipeline for basic remote sensing analysis. The code is structured for future extensions such as polygon data integration and asset value analysis.
 
 
@@ -41,6 +75,13 @@ remote_sensing/
 4. Train a RandomForest model using `train_model.py` and your label raster.
 5. Apply the model with `predict.py` to generate a classification raster.
 6. View results in a Streamlit app (`app.py`).
+
+For a one-shot workflow using Sentinel‑2 bands you can also execute:
+
+```bash
+python src/classification/pipeline.py --help
+```
+
 
 ## Running the pipeline
 

--- a/src/classification/pipeline.py
+++ b/src/classification/pipeline.py
@@ -1,0 +1,38 @@
+import argparse
+import rasterio
+
+from ..preprocess.cloudmask import cloud_mask
+from ..preprocess.stack_bands import stack_bands
+from ..preprocess.features import compute_features
+from .train_model import train_model
+from .predict import predict_model
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sentinel-2 land use classification pipeline")
+    parser.add_argument("--bands", nargs=5, metavar="BAND", help="Paths to Sentinel-2 bands (B02,B03,B04,B08,B11)")
+    parser.add_argument("--qa", required=True, help="Path to QA band for cloud masking")
+    parser.add_argument("--labels", required=True, help="Raster path with training labels")
+    parser.add_argument("--output", default="outputs/prediction.tif", help="Output path for classification result")
+    parser.add_argument("--n_estimators", type=int, default=100, help="Number of trees for RandomForest")
+    args = parser.parse_args()
+
+    mask = cloud_mask(args.qa)
+    stack, meta = stack_bands(args.bands, mask)
+
+    # Sentinel-2 indices: provided order is B02, B03, B04, B08, B11
+    red_idx = 2
+    nir_idx = 3
+    swir_idx = 4
+    features = compute_features(stack, red_idx=red_idx, nir_idx=nir_idx, swir_idx=swir_idx)
+
+    with rasterio.open(args.labels) as src:
+        labels = src.read(1)
+
+    clf = train_model(features, labels, n_estimators=args.n_estimators)
+
+    predict_model(clf, features, meta, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a classification pipeline script for Sentinel-2 data
- update README with step-by-step instructions

## Testing
- `python -m compileall -q src remote_sensing`

------
https://chatgpt.com/codex/tasks/task_b_684293ca82ec8320a38cd41789f94aa7