### PR TITLE
Add .gitignore with Python defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Byte-compiled / optimized files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv/
+venv/
+ENV/
+env/
+
+# Editor directories and files
+.idea/
+.vscode/
+
+# Data and output directories
+data/
+outputs/
+
+# Local virtual env
+.venv/


### PR DESCRIPTION
## Summary
- add `.gitignore` containing typical Python ignore patterns
- ignore project data, output folders and `.venv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68429cdefea08320be3c75453d9b1db6