### PR TITLE
Add environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ streamlit run src/app.py
 This repository contains a minimal example of a Python pipeline for basic remote sensing analysis. The code is structured for future extensions such as polygon data integration and asset value analysis.
 
 ## Installation
-Run `pip install -r requirements.txt` to create a reproducible Python environment.
+Use the helper script to create a virtual environment and install the dependencies:
+
+```bash
+bash scripts/setup_env.sh
+```
 
 
 
@@ -101,6 +105,12 @@ python -m src.classification.pipeline --help
 
 
 ## Running the pipeline
+
+Before executing the pipeline make sure the environment is ready:
+
+```bash
+bash scripts/setup_env.sh
+```
 
 The `remote_sensing.pipeline` module exposes a `run_pipeline` function and a simple CLI. It expects preprocessed NumPy arrays for the red and near-infrared bands.
 

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR/.."
+cd "$PROJECT_ROOT"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Virtual environment created. Activate it with 'source venv/bin/activate'."


### PR DESCRIPTION
## Summary
- add `scripts/setup_env.sh` to create a virtual environment and install requirements
- document new setup script usage in the README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `bash -n scripts/setup_env.sh`

------
https://chatgpt.com/codex/tasks/task_b_68429f32871883208b4136c354488270