### PR TITLE
Add script for caching Sentinel downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ remote_sensing/
 - A QA band from which clouds can be detected
 - A raster of training labels for model fitting
 
+### Automated Sentinel‑2 download
+
+You can fetch sample imagery directly from the Copernicus Open Access Hub using
+`scripts/download_sentinel.py`. The script caches downloads under
+`data/raw/<SATELLITE>` based on location and time range.
+
+```bash
+export SENTINEL_USER=<your username>
+export SENTINEL_PASSWORD=<your password>
+python scripts/download_sentinel.py \
+  --lat 35.6 \
+  --lon 139.7 \
+  --start 2024-01-01 \
+  --end 2024-01-31
+```
+
+If the target folder already exists the previously downloaded data will be
+reused.
+
 ## Usage
 
 1. Run `cloudmask.py` to derive a boolean mask of clouds from the QA band.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scikit-learn==1.4.1
 streamlit==1.31.1
 folium==0.15.1
 streamlit_folium==0.11.2
+sentinelsat==1.2.1

--- a/scripts/download_sentinel.py
+++ b/scripts/download_sentinel.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""Download Sentinel data into the data/raw directory with caching."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Tuple
+
+from sentinelsat import SentinelAPI
+
+
+def build_output_dir(satellite: str, lat: float, lon: float, start: str, end: str) -> Path:
+    """Construct and create an output directory based on query parameters."""
+    base = Path("data/raw") / satellite
+    # limit decimals to 4 places to keep path short and consistent
+    loc = f"{lat:.4f}_{lon:.4f}"
+    name = f"{loc}_{start}_{end}"
+    out_dir = base / name
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download Sentinel imagery with caching")
+    parser.add_argument("--lat", type=float, required=True, help="Latitude")
+    parser.add_argument("--lon", type=float, required=True, help="Longitude")
+    parser.add_argument("--start", required=True, help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", required=True, help="End date YYYY-MM-DD")
+    parser.add_argument("--satellite", default="Sentinel-2", help="Satellite platform name")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    out_dir = build_output_dir(args.satellite, args.lat, args.lon, args.start, args.end)
+
+    if any(out_dir.iterdir()):
+        print(f"Using cached data in {out_dir}")
+        return
+
+    user = os.getenv("SENTINEL_USER")
+    password = os.getenv("SENTINEL_PASSWORD")
+    if not user or not password:
+        raise RuntimeError("Set SENTINEL_USER and SENTINEL_PASSWORD environment variables")
+
+    api = SentinelAPI(user, password, "https://scihub.copernicus.eu/dhus")
+    footprint = f"POINT({args.lon} {args.lat})"
+    products = api.query(
+        footprint,
+        date=(args.start, args.end),
+        platformname=args.satellite,
+        processinglevel="Level-2A",
+    )
+
+    if not products:
+        print("No products found for given parameters")
+        return
+
+    api.download_all(products, directory_path=str(out_dir))
+    print(f"Downloaded {len(products)} product(s) to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/download_sentinel.py` to fetch Sentinel-2 imagery using sentinelsat and cache results
- document usage of the new script in the README
- include `sentinelsat` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842a994e0d883209a59d200dd88a133