### PR TITLE
Document config file copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ python -m src.classification.pipeline --help
 
 ### Config based Sentinel-2 workflow
 
-Each processing step accepts a YAML configuration file. Example configs are in
-the `configs/` directory. Run the full workflow with:
+Each processing step accepts a YAML configuration file and writes a copy of
+that file into its output directory for reference. Example configs are in the
+`configs/` directory. Run the full workflow with:
 
 ```bash
 bash scripts/run_sentinel2_pipeline.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,7 +19,9 @@ source venv/bin/activate
 ## `download_sentinel.py`
 Downloads Sentinel imagery from the Copernicus Open Access Hub.
 The module resides under `src/utils/` and caches files inside
-`data/raw/<SATELLITE>` based on the selected location and date range.
+`data/raw/<SATELLITE>` based on the selected location and date range. When run
+with a YAML configuration, the file is copied into the download directory for
+future reference.
 
 Example usage:
 
@@ -31,7 +33,9 @@ python -m src.utils.download_sentinel --lat 35.6 --lon 139.7 --start 2024-01-01 
 
 ## `run_sentinel2_pipeline.sh`
 A helper script that runs the full Sentinel-2 workflow using the configuration
-files stored in `configs/`.
+files stored in `configs/`. Each pipeline step copies its YAML configuration
+into the corresponding output folder so parameters are recorded alongside the
+results.
 
 ```bash
 bash scripts/run_sentinel2_pipeline.sh


### PR DESCRIPTION
## Summary
- note that YAML configs are copied into each output directory
- mention the behavior for download and pipeline scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68468b9d65b083209857d8ff733b172a