### PR TITLE
Split Sentinel pipeline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ that file into its output directory for reference. Example configs are in the
 bash scripts/run_sentinel2_pipeline.sh
 ```
 
+Individual steps can also be executed via the helper scripts in `scripts/`:
+
+```bash
+bash scripts/download_sentinel2.sh <out_dir> configs/download.yaml
+bash scripts/preprocess_sentinel2.sh <download_dir> <features_dir> configs/preprocess.yaml
+bash scripts/train_model.sh <features_dir> <model_dir> configs/train.yaml
+bash scripts/predict_sentinel2.sh <features_dir> <model_dir> <pred_dir> configs/predict.yaml
+```
+
 
 ## Running the pipeline
 

--- a/scripts/download_sentinel2.sh
+++ b/scripts/download_sentinel2.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 OUTPUT_DIR CONFIG" >&2
+    exit 1
+fi
+
+OUTPUT_DIR="$1"
+CONFIG="$2"
+
+python -m src.pipeline.download --config "$CONFIG" --output "$OUTPUT_DIR"
+

--- a/scripts/predict_sentinel2.sh
+++ b/scripts/predict_sentinel2.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 FEATURES_DIR MODEL_DIR OUTPUT_DIR CONFIG" >&2
+    exit 1
+fi
+
+FEATURES_DIR="$1"
+MODEL_DIR="$2"
+OUTPUT_DIR="$3"
+CONFIG="$4"
+
+python -m src.pipeline.predict --config "$CONFIG" \
+    --features-dir "$FEATURES_DIR" --model-dir "$MODEL_DIR" \
+    --output-dir "$OUTPUT_DIR"
+

--- a/scripts/preprocess_sentinel2.sh
+++ b/scripts/preprocess_sentinel2.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 INPUT_DIR OUTPUT_DIR CONFIG" >&2
+    exit 1
+fi
+
+INPUT_DIR="$1"
+OUTPUT_DIR="$2"
+CONFIG="$3"
+
+python -m src.pipeline.preprocess --config "$CONFIG" \
+    --input-dir "$INPUT_DIR" --output-dir "$OUTPUT_DIR"
+

--- a/scripts/run_sentinel2_pipeline.sh
+++ b/scripts/run_sentinel2_pipeline.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python -m src.pipeline.download --config configs/download.yaml
-python -m src.pipeline.preprocess --config configs/preprocess.yaml
-python -m src.pipeline.train --config configs/train.yaml
-python -m src.pipeline.predict --config configs/predict.yaml
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DOWNLOAD_DIR="data/raw/example_run"
+FEATURE_DIR="data/processed/example_run"
+MODEL_DIR="outputs/model_example"
+PREDICT_DIR="outputs/prediction_example"
+
+bash "$SCRIPT_DIR/download_sentinel2.sh" "$DOWNLOAD_DIR" configs/download.yaml
+bash "$SCRIPT_DIR/preprocess_sentinel2.sh" "$DOWNLOAD_DIR" "$FEATURE_DIR" configs/preprocess.yaml
+bash "$SCRIPT_DIR/train_model.sh" "$FEATURE_DIR" "$MODEL_DIR" configs/train.yaml
+bash "$SCRIPT_DIR/predict_sentinel2.sh" "$FEATURE_DIR" "$MODEL_DIR" "$PREDICT_DIR" configs/predict.yaml
 

--- a/scripts/train_model.sh
+++ b/scripts/train_model.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 INPUT_DIR OUTPUT_DIR CONFIG" >&2
+    exit 1
+fi
+
+INPUT_DIR="$1"
+OUTPUT_DIR="$2"
+CONFIG="$3"
+
+python -m src.pipeline.train --config "$CONFIG" \
+    --input-dir "$INPUT_DIR" --output-dir "$OUTPUT_DIR"
+

--- a/src/pipeline/download.py
+++ b/src/pipeline/download.py
@@ -9,9 +9,10 @@ from ..utils import download_sentinel
 def main() -> None:
     parser = argparse.ArgumentParser(description="Download Sentinel data using a config file")
     parser.add_argument("--config", required=True, help="Path to YAML config")
+    parser.add_argument("--output", required=True, help="Output directory")
     args = parser.parse_args()
 
-    out_dir = download_sentinel.download_from_config(args.config)
+    out_dir = download_sentinel.download_from_config(args.config, args.output)
     shutil.copy(args.config, Path(out_dir) / Path(args.config).name)
 
 

--- a/src/pipeline/predict.py
+++ b/src/pipeline/predict.py
@@ -13,17 +13,26 @@ from ..classification.predict import predict_model
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run model inference")
     parser.add_argument("--config", required=True, help="YAML config file")
+    parser.add_argument("--features-dir", required=True, help="Directory with features file")
+    parser.add_argument("--model-dir", required=True, help="Directory with trained model")
+    parser.add_argument("--output-dir", required=True, help="Directory for prediction result")
     args = parser.parse_args()
 
     with open(args.config) as f:
         cfg = yaml.safe_load(f)
 
-    data = np.load(cfg["features"])["features"]
-    with open(cfg.get("meta", Path(cfg["features"]).with_suffix(".meta.json"))) as f:
+    features_dir = Path(args.features_dir)
+    model_dir = Path(args.model_dir)
+    output_dir = Path(args.output_dir)
+
+    features_path = features_dir / Path(cfg["features"]).name
+    data = np.load(features_path)["features"]
+    meta_path = features_dir / Path(cfg.get("meta", Path(cfg["features"]).with_suffix(".meta.json"))).name
+    with open(meta_path) as f:
         meta = json.load(f)
 
-    clf = joblib.load(cfg["model"])
-    out_path = Path(cfg.get("output", "outputs/prediction.tif"))
+    clf = joblib.load(model_dir / Path(cfg["model"]).name)
+    out_path = output_dir / Path(cfg.get("output", "prediction.tif")).name
     out_path.parent.mkdir(parents=True, exist_ok=True)
     predict_model(clf, data, meta, out_path)
 

--- a/src/pipeline/preprocess.py
+++ b/src/pipeline/preprocess.py
@@ -15,16 +15,24 @@ from ..preprocess.features import compute_features
 def main() -> None:
     parser = argparse.ArgumentParser(description="Preprocess Sentinel bands")
     parser.add_argument("--config", required=True, help="YAML config file")
+    parser.add_argument("--input-dir", required=True, help="Directory with raw bands")
+    parser.add_argument("--output-dir", required=True, help="Directory for features")
     args = parser.parse_args()
 
     with open(args.config) as f:
         cfg = yaml.safe_load(f)
 
-    mask = cloud_mask(cfg["qa"])
-    stack, meta = stack_bands(cfg["bands"], mask)
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+
+    bands = [input_dir / Path(p).name for p in cfg["bands"]]
+    qa_path = input_dir / Path(cfg["qa"]).name
+
+    mask = cloud_mask(qa_path)
+    stack, meta = stack_bands(bands, mask)
     features = compute_features(stack, red_idx=2, nir_idx=3, swir_idx=4)
 
-    out_path = Path(cfg.get("features_out", "data/processed/features.npz"))
+    out_path = output_dir / Path(cfg.get("features_out", "features.npz")).name
     out_path.parent.mkdir(parents=True, exist_ok=True)
     np.savez(out_path, features=features)
     with open(out_path.with_suffix(".meta.json"), "w") as f:

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -13,18 +13,24 @@ from ..classification.train_model import train_model
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train classification model")
     parser.add_argument("--config", required=True, help="YAML config file")
+    parser.add_argument("--input-dir", required=True, help="Directory with feature file")
+    parser.add_argument("--output-dir", required=True, help="Directory for model")
     args = parser.parse_args()
 
     with open(args.config) as f:
         cfg = yaml.safe_load(f)
 
-    data = np.load(cfg["features"])["features"]
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+
+    features_path = input_dir / Path(cfg["features"]).name
+    data = np.load(features_path)["features"]
     with rasterio.open(cfg["labels"]) as src:
         labels = src.read(1)
 
     clf = train_model(data, labels, n_estimators=cfg.get("n_estimators", 100))
 
-    model_path = Path(cfg.get("model_out", "outputs/model.pkl"))
+    model_path = output_dir / Path(cfg.get("model_out", "model.pkl")).name
     model_path.parent.mkdir(parents=True, exist_ok=True)
     joblib.dump(clf, model_path)
 


### PR DESCRIPTION
## Summary
- split the pipeline into per-step shell scripts
- allow each step to specify input/output directories
- copy config to outputs
- document running individual steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68468db083808320a75f66256dbabd78