### PR TITLE
Embed path variables inside helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ bash scripts/run_sentinel2_pipeline.sh
 Individual steps can also be executed via the helper scripts in `scripts/`:
 
 ```bash
-bash scripts/download_sentinel2.sh <out_dir> configs/download.yaml
-bash scripts/preprocess_sentinel2.sh <download_dir> <features_dir> configs/preprocess.yaml
-bash scripts/train_model.sh <features_dir> <model_dir> configs/train.yaml
-bash scripts/predict_sentinel2.sh <features_dir> <model_dir> <pred_dir> configs/predict.yaml
+bash scripts/download_sentinel2.sh
+bash scripts/preprocess_sentinel2.sh
+bash scripts/train_model.sh
+bash scripts/predict_sentinel2.sh
 ```
 
 

--- a/scripts/download_sentinel2.sh
+++ b/scripts/download_sentinel2.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 OUTPUT_DIR CONFIG" >&2
-    exit 1
-fi
+# Directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-OUTPUT_DIR="$1"
-CONFIG="$2"
+# Hard coded paths for a single example run
+OUTPUT_DIR="data/raw/example_run"
+CONFIG="configs/download.yaml"
 
 python -m src.pipeline.download --config "$CONFIG" --output "$OUTPUT_DIR"
 

--- a/scripts/predict_sentinel2.sh
+++ b/scripts/predict_sentinel2.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 4 ]; then
-    echo "Usage: $0 FEATURES_DIR MODEL_DIR OUTPUT_DIR CONFIG" >&2
-    exit 1
-fi
+# Directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-FEATURES_DIR="$1"
-MODEL_DIR="$2"
-OUTPUT_DIR="$3"
-CONFIG="$4"
+# Hard coded paths for a single example run
+FEATURES_DIR="data/processed/example_run"
+MODEL_DIR="outputs/model_example"
+OUTPUT_DIR="outputs/prediction_example"
+CONFIG="configs/predict.yaml"
 
 python -m src.pipeline.predict --config "$CONFIG" \
     --features-dir "$FEATURES_DIR" --model-dir "$MODEL_DIR" \

--- a/scripts/preprocess_sentinel2.sh
+++ b/scripts/preprocess_sentinel2.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 INPUT_DIR OUTPUT_DIR CONFIG" >&2
-    exit 1
-fi
+# Directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-INPUT_DIR="$1"
-OUTPUT_DIR="$2"
-CONFIG="$3"
+# Hard coded paths for a single example run
+INPUT_DIR="data/raw/example_run"
+OUTPUT_DIR="data/processed/example_run"
+CONFIG="configs/preprocess.yaml"
 
 python -m src.pipeline.preprocess --config "$CONFIG" \
     --input-dir "$INPUT_DIR" --output-dir "$OUTPUT_DIR"

--- a/scripts/run_sentinel2_pipeline.sh
+++ b/scripts/run_sentinel2_pipeline.sh
@@ -3,13 +3,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-DOWNLOAD_DIR="data/raw/example_run"
-FEATURE_DIR="data/processed/example_run"
-MODEL_DIR="outputs/model_example"
-PREDICT_DIR="outputs/prediction_example"
-
-bash "$SCRIPT_DIR/download_sentinel2.sh" "$DOWNLOAD_DIR" configs/download.yaml
-bash "$SCRIPT_DIR/preprocess_sentinel2.sh" "$DOWNLOAD_DIR" "$FEATURE_DIR" configs/preprocess.yaml
-bash "$SCRIPT_DIR/train_model.sh" "$FEATURE_DIR" "$MODEL_DIR" configs/train.yaml
-bash "$SCRIPT_DIR/predict_sentinel2.sh" "$FEATURE_DIR" "$MODEL_DIR" "$PREDICT_DIR" configs/predict.yaml
+# Simply invoke each helper script which defines its own paths
+bash "$SCRIPT_DIR/download_sentinel2.sh"
+bash "$SCRIPT_DIR/preprocess_sentinel2.sh"
+bash "$SCRIPT_DIR/train_model.sh"
+bash "$SCRIPT_DIR/predict_sentinel2.sh"
 

--- a/scripts/train_model.sh
+++ b/scripts/train_model.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 INPUT_DIR OUTPUT_DIR CONFIG" >&2
-    exit 1
-fi
+# Directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-INPUT_DIR="$1"
-OUTPUT_DIR="$2"
-CONFIG="$3"
+# Hard coded paths for a single example run
+INPUT_DIR="data/processed/example_run"
+OUTPUT_DIR="outputs/model_example"
+CONFIG="configs/train.yaml"
 
 python -m src.pipeline.train --config "$CONFIG" \
     --input-dir "$INPUT_DIR" --output-dir "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- hard-code example directories and config paths inside each helper script
- simplify `run_sentinel2_pipeline.sh` to call scripts without arguments
- update README instructions for running individual steps

## Testing
- `bash -n scripts/download_sentinel2.sh`
- `bash -n scripts/preprocess_sentinel2.sh`
- `bash -n scripts/train_model.sh`
- `bash -n scripts/predict_sentinel2.sh`
- `bash -n scripts/run_sentinel2_pipeline.sh`


------
https://chatgpt.com/codex/tasks/task_b_6846aacb680883208a9cadf97a2ce35d