### PR TITLE
Update Sentinel API URL to Copernicus Data Space

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ NumPy arrays only.
 
 ### Automated Sentinel‑2 download
 
-You can fetch sample imagery directly from the Copernicus Open Access Hub using
-`src/utils/download_sentinel.py`. The module caches downloads under
+You can fetch sample imagery directly from the Copernicus Data Space using
+`src/utils/download_sentinel.py`. The tool connects to
+`https://apihub.copernicus.eu/apihub` and caches downloads under
 `data/raw/<SATELLITE>` based on location and time range.
 
 ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,8 @@ source venv/bin/activate
 ```
 
 ## `download_sentinel.py`
-Downloads Sentinel imagery from the Copernicus Open Access Hub.
+Downloads Sentinel imagery from the Copernicus Data Space via
+`https://apihub.copernicus.eu/apihub`.
 The module resides under `src/utils/` and caches files inside
 `data/raw/<SATELLITE>` based on the selected location and date range. When run
 with a YAML configuration, the file is copied into the download directory for

--- a/src/utils/download_sentinel.py
+++ b/src/utils/download_sentinel.py
@@ -81,7 +81,7 @@ def download_sentinel(
     if not user or not password:
         raise RuntimeError("Set SENTINEL_USER and SENTINEL_PASSWORD environment variables")
 
-    api = SentinelAPI(user, password, "https://scihub.copernicus.eu/dhus")
+    api = SentinelAPI(user, password, "https://apihub.copernicus.eu/apihub")
     footprint = f"POINT({lon} {lat})"
     norm_start = normalize_date(start)
     norm_end = normalize_date(end)


### PR DESCRIPTION
## Summary
- update Sentinel API endpoint in `download_sentinel.py`
- adjust documentation to mention Copernicus Data Space and new API URL

## Testing
- `python -m py_compile src/utils/download_sentinel.py`
- `python -m src.utils.download_sentinel --help` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6846c6c93a3483208a93c6420c387c50