### PR TITLE
Add note about outbound HTTPS access

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ You can fetch sample imagery directly from the Copernicus Data Space using
 `https://apihub.copernicus.eu/apihub` and caches downloads under
 `data/raw/<SATELLITE>` based on location and time range.
 
+> **Note**
+> The download scripts require outbound HTTPS access to
+> `apihub.copernicus.eu`. Connection issues such as timeouts or
+> "No route to host" usually mean your network is restricted. Configure a
+> proxy if needed.
+
 ```bash
 export SENTINEL_USER=<your username>
 export SENTINEL_PASSWORD=<your password>

--- a/docs/sentinelsat_setup.md
+++ b/docs/sentinelsat_setup.md
@@ -12,3 +12,9 @@ export SENTINEL_PASSWORD=<your password>
 ```
 
 The script will cache downloaded products under `data/raw/<SATELLITE>` based on the provided coordinates and date range. Subsequent runs with the same parameters will reuse the cached files.
+
+> **Note**
+> Downloads are performed over HTTPS to `apihub.copernicus.eu`. If you
+> experience timeouts or errors like "No route to host", your environment
+> might block outbound connections. Configure network access or use an
+> HTTPS proxy if necessary.


### PR DESCRIPTION
## Summary
- mention that `apihub.copernicus.eu` needs outbound HTTPS access
- mention errors like timeouts or "No route to host" probably mean network restrictions
- suggest using a proxy

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6846c9952450832088259fa527929cb0