### PR TITLE
Add configurable Sentinel API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,15 @@ NumPy arrays only.
 
 You can fetch sample imagery directly from the Copernicus Data Space using
 `src/utils/download_sentinel.py`. The tool connects to
-`https://apihub.copernicus.eu/apihub` and caches downloads under
-`data/raw/<SATELLITE>` based on location and time range.
+`https://apihub.copernicus.eu/apihub` by default and caches downloads under
+`data/raw/<SATELLITE>` based on location and time range. Use `--api-url` to
+override the endpoint if needed.
 
 > **Note**
 > The download scripts require outbound HTTPS access to
-> `apihub.copernicus.eu`. Connection issues such as timeouts or
-> "No route to host" usually mean your network is restricted. Configure a
-> proxy if needed.
+> `apihub.copernicus.eu` (or the URL passed via `--api-url`). Connection
+> issues such as timeouts or "No route to host" usually mean your network is
+> restricted. Configure a proxy if needed.
 
 ```bash
 export SENTINEL_USER=<your username>
@@ -121,7 +122,8 @@ python -m src.utils.download_sentinel \
   --lat 35.6 \
   --lon 139.7 \
   --start 2024-01-01 \
-  --end 2024-01-31
+  --end 2024-01-31 \
+  # --api-url https://alternative.example.com/apihub
 ```
 
 If the target folder already exists the previously downloaded data will be

--- a/docs/sentinelsat_setup.md
+++ b/docs/sentinelsat_setup.md
@@ -11,10 +11,7 @@ export SENTINEL_USER=<your username>
 export SENTINEL_PASSWORD=<your password>
 ```
 
-The script will cache downloaded products under `data/raw/<SATELLITE>` based on the provided coordinates and date range. Subsequent runs with the same parameters will reuse the cached files.
+The script will cache downloaded products under `data/raw/<SATELLITE>` based on the provided coordinates and date range. It talks to `https://apihub.copernicus.eu/apihub` by default. Subsequent runs with the same parameters will reuse the cached files. Use `--api-url` to override the endpoint if your mirror is hosted elsewhere.
 
 > **Note**
-> Downloads are performed over HTTPS to `apihub.copernicus.eu`. If you
-> experience timeouts or errors like "No route to host", your environment
-> might block outbound connections. Configure network access or use an
-> HTTPS proxy if necessary.
+> Downloads are performed over HTTPS to `apihub.copernicus.eu` (unless you specify `--api-url`). If you experience timeouts or errors like "No route to host", your environment might block outbound connections. Configure network access or use an HTTPS proxy if necessary.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,7 +18,8 @@ source venv/bin/activate
 
 ## `download_sentinel.py`
 Downloads Sentinel imagery from the Copernicus Data Space via
-`https://apihub.copernicus.eu/apihub`.
+`https://apihub.copernicus.eu/apihub` by default.
+Pass `--api-url` to use a different endpoint.
 The module resides under `src/utils/` and caches files inside
 `data/raw/<SATELLITE>` based on the selected location and date range. When run
 with a YAML configuration, the file is copied into the download directory for
@@ -29,7 +30,8 @@ Example usage:
 ```bash
 export SENTINEL_USER=<your username>
 export SENTINEL_PASSWORD=<your password>
-python -m src.utils.download_sentinel --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31
+python -m src.utils.download_sentinel --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31 \
+  # --api-url https://alternative.example.com/apihub
 ```
 
 ## `run_sentinel2_pipeline.sh`

--- a/scripts/download_sentinel2.sh
+++ b/scripts/download_sentinel2.sh
@@ -8,5 +8,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT_DIR="data/raw/example_run"
 CONFIG="configs/download.yaml"
 
-python -m src.pipeline.download --config "$CONFIG" --output "$OUTPUT_DIR"
+python -m src.pipeline.download --config "$CONFIG" --output "$OUTPUT_DIR" \
+  # --api-url https://alternative.example.com/apihub
 

--- a/src/pipeline/download.py
+++ b/src/pipeline/download.py
@@ -8,9 +8,10 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Download Sentinel data using a config file")
     parser.add_argument("--config", required=True, help="Path to YAML config")
     parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--api-url", default=download_sentinel.DEFAULT_API_URL, help="Sentinel API endpoint")
     args = parser.parse_args()
 
-    out_dir = download_sentinel.download_from_config(args.config, args.output)
+    out_dir = download_sentinel.download_from_config(args.config, args.output, args.api_url)
     shutil.copy(args.config, Path(out_dir) / Path(args.config).name)
 
 


### PR DESCRIPTION
## Summary
- allow overriding the Sentinel API URL with `--api-url`
- document the new option in README and docs
- mention the flag in helper scripts and pipeline

## Testing
- `python -m src.utils.download_sentinel --help` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_6846cd00ed8083209bb37777362b1688