### PR TITLE
Use sentinelhub for Sentinel downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,26 +104,23 @@ NumPy arrays only.
 ### Automated Sentinel‑2 download
 
 You can fetch sample imagery directly from the Copernicus Data Space using
-`src/utils/download_sentinel.py`. The tool connects to
-`https://apihub.copernicus.eu/apihub` by default and caches downloads under
-`data/raw/<SATELLITE>` based on location and time range. Use `--api-url` to
-override the endpoint if needed.
+`src/utils/download_sentinel.py`. The script relies on **sentinelhub-py** and
+queries the `https://sh.dataspace.copernicus.eu` service. Downloads are cached
+under `data/raw/<SATELLITE>` based on location and time range.
 
 > **Note**
 > The download scripts require outbound HTTPS access to
-> `apihub.copernicus.eu` (or the URL passed via `--api-url`). Connection
-> issues such as timeouts or "No route to host" usually mean your network is
-> restricted. Configure a proxy if needed.
+> `sh.dataspace.copernicus.eu`. Connection issues such as timeouts or "No route to host"
+> usually mean your network is restricted. Configure a proxy if needed.
 
 ```bash
-export SENTINEL_USER=<your username>
-export SENTINEL_PASSWORD=<your password>
+export SENTINELHUB_CLIENT_ID=<your client id>
+export SENTINELHUB_CLIENT_SECRET=<your client secret>
 python -m src.utils.download_sentinel \
   --lat 35.6 \
   --lon 139.7 \
   --start 2024-01-01 \
-  --end 2024-01-31 \
-  # --api-url https://alternative.example.com/apihub
+  --end 2024-01-31
 ```
 
 If the target folder already exists the previously downloaded data will be

--- a/docs/sentinelsat_setup.md
+++ b/docs/sentinelsat_setup.md
@@ -1,17 +1,23 @@
-# Using Sentinelsat
+# Copernicus Data Space authentication
 
-This project uses **sentinelsat** to download Sentinel imagery from the Copernicus Data Space Ecosystem. You need a valid account in order to authenticate.
+The downloader uses **sentinelhub-py** which requires OAuth credentials.
+Create a free account at <https://dataspace.copernicus.eu/> and generate an
+application to obtain a client ID and secret.
 
-1. Visit <https://shapps.dataspace.copernicus.eu/dashboard/#/> and sign up for an account.
-2. After registration, note your username and password.
-3. Set them as environment variables before running `download_sentinel.py`:
+1. Visit <https://dataspace.copernicus.eu/> and register.
+2. In the dashboard create a new OAuth client and note its ID and secret.
+3. Export them before running `download_sentinel.py`:
 
 ```bash
-export SENTINEL_USER=<your username>
-export SENTINEL_PASSWORD=<your password>
+export SENTINELHUB_CLIENT_ID=<your client id>
+export SENTINELHUB_CLIENT_SECRET=<your client secret>
 ```
 
-The script will cache downloaded products under `data/raw/<SATELLITE>` based on the provided coordinates and date range. It talks to `https://apihub.copernicus.eu/apihub` by default. Subsequent runs with the same parameters will reuse the cached files. Use `--api-url` to override the endpoint if your mirror is hosted elsewhere.
+Downloads are cached under `data/raw/<SATELLITE>` based on the selected
+location and date range. Requests are sent to
+`https://sh.dataspace.copernicus.eu`. If the directory already exists the
+cached files will be reused.
 
 > **Note**
-> Downloads are performed over HTTPS to `apihub.copernicus.eu` (unless you specify `--api-url`). If you experience timeouts or errors like "No route to host", your environment might block outbound connections. Configure network access or use an HTTPS proxy if necessary.
+> Network access to `sh.dataspace.copernicus.eu` is required. Configure a proxy
+> if your environment restricts outbound HTTPS connections.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ streamlit==1.31.1
 folium==0.15.1
 streamlit_folium==0.11.2
 PyYAML==6.0.2
-sentinelsat==1.2.1
+sentinelhub==3.10.1
 
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,9 +17,8 @@ source venv/bin/activate
 ```
 
 ## `download_sentinel.py`
-Downloads Sentinel imagery from the Copernicus Data Space via
-`https://apihub.copernicus.eu/apihub` by default.
-Pass `--api-url` to use a different endpoint.
+Downloads Sentinel imagery from the Copernicus Data Space using the
+`sentinelhub` service at `https://sh.dataspace.copernicus.eu`.
 The module resides under `src/utils/` and caches files inside
 `data/raw/<SATELLITE>` based on the selected location and date range. When run
 with a YAML configuration, the file is copied into the download directory for
@@ -28,10 +27,9 @@ future reference.
 Example usage:
 
 ```bash
-export SENTINEL_USER=<your username>
-export SENTINEL_PASSWORD=<your password>
-python -m src.utils.download_sentinel --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31 \
-  # --api-url https://alternative.example.com/apihub
+export SENTINELHUB_CLIENT_ID=<your client id>
+export SENTINELHUB_CLIENT_SECRET=<your client secret>
+python -m src.utils.download_sentinel --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31
 ```
 
 ## `run_sentinel2_pipeline.sh`

--- a/scripts/download_sentinel2.sh
+++ b/scripts/download_sentinel2.sh
@@ -8,6 +8,5 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT_DIR="data/raw/example_run"
 CONFIG="configs/download.yaml"
 
-python -m src.pipeline.download --config "$CONFIG" --output "$OUTPUT_DIR" \
-  # --api-url https://alternative.example.com/apihub
+python -m src.pipeline.download --config "$CONFIG" --output "$OUTPUT_DIR"
 

--- a/src/pipeline/download.py
+++ b/src/pipeline/download.py
@@ -8,10 +8,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Download Sentinel data using a config file")
     parser.add_argument("--config", required=True, help="Path to YAML config")
     parser.add_argument("--output", required=True, help="Output directory")
-    parser.add_argument("--api-url", default=download_sentinel.DEFAULT_API_URL, help="Sentinel API endpoint")
     args = parser.parse_args()
 
-    out_dir = download_sentinel.download_from_config(args.config, args.output, args.api_url)
+    out_dir = download_sentinel.download_from_config(args.config, args.output)
     shutil.copy(args.config, Path(out_dir) / Path(args.config).name)
 
 


### PR DESCRIPTION
## Summary
- swap out `sentinelsat` for `sentinelhub`
- rewrite Sentinel download helper to use sentinelhub API
- update pipeline and helper scripts for the new downloader
- document Copernicus Data Space authentication via sentinelhub

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6846dd52b3dc8320b3add7cf27015d09