### PR TITLE
Set sentinelhub base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ under `data/raw/<SATELLITE>` based on location and time range.
 ```bash
 export SENTINELHUB_CLIENT_ID=<your client id>
 export SENTINELHUB_CLIENT_SECRET=<your client secret>
+export SH_BASE_URL=https://sh.dataspace.copernicus.eu
 python -m src.utils.download_sentinel \
   --lat 35.6 \
   --lon 139.7 \

--- a/docs/sentinelsat_setup.md
+++ b/docs/sentinelsat_setup.md
@@ -11,6 +11,7 @@ application to obtain a client ID and secret.
 ```bash
 export SENTINELHUB_CLIENT_ID=<your client id>
 export SENTINELHUB_CLIENT_SECRET=<your client secret>
+export SH_BASE_URL=https://sh.dataspace.copernicus.eu
 ```
 
 Downloads are cached under `data/raw/<SATELLITE>` based on the selected

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,6 +29,7 @@ Example usage:
 ```bash
 export SENTINELHUB_CLIENT_ID=<your client id>
 export SENTINELHUB_CLIENT_SECRET=<your client secret>
+export SH_BASE_URL=https://sh.dataspace.copernicus.eu
 python -m src.utils.download_sentinel --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31
 ```
 

--- a/src/utils/download_sentinel.py
+++ b/src/utils/download_sentinel.py
@@ -99,6 +99,8 @@ def download_sentinel(
     config = SHConfig()
     config.sh_client_id = client_id
     config.sh_client_secret = client_secret
+    # Use the Copernicus Data Space endpoint
+    config.sh_base_url = "https://sh.dataspace.copernicus.eu"
 
     bbox = BBox(
         (lon - buffer, lat - buffer, lon + buffer, lat + buffer), crs=CRS.WGS84


### PR DESCRIPTION
## Summary
- configure sentinelhub to use the Copernicus Data Space endpoint
- document SH_BASE_URL in instructions

## Testing
- `python -m py_compile src/utils/download_sentinel.py`
- `python -m py_compile src/pipeline/download.py`


------
https://chatgpt.com/codex/tasks/task_b_6846dc8a6e2083209eb6d043a2c4b74c