### PR TITLE
Allow overriding SentinelHub endpoints

### DIFF
--- a/docs/sentinelhub_setup.md
+++ b/docs/sentinelhub_setup.md
@@ -6,7 +6,7 @@ application to obtain a client ID and secret.
 
 1. Visit <https://dataspace.copernicus.eu/> and register.
 2. In the dashboard create a new OAuth client and note its ID and secret.
-3. Export them before running `download_sentinel.py`:
+3. Export them before running `download_sentinel.py` (or pass via CLI):
 
 ```bash
 export SENTINELHUB_CLIENT_ID=<your client id>
@@ -14,6 +14,10 @@ export SENTINELHUB_CLIENT_SECRET=<your client secret>
 export SH_BASE_URL=https://sh.dataspace.copernicus.eu
 export SH_AUTH_BASE_URL=https://identity.dataspace.copernicus.eu
 ```
+
+Alternatively provide `--sh-base-url` and `--sh-auth-base-url` when running
+`download_sentinel.py` or the pipeline downloader to override these endpoints
+without setting environment variables.
 
 Downloads are cached under `data/raw/<SATELLITE>` based on the selected
 location and date range. Requests are sent to

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,8 +31,12 @@ export SENTINELHUB_CLIENT_ID=<your client id>
 export SENTINELHUB_CLIENT_SECRET=<your client secret>
 export SH_BASE_URL=https://sh.dataspace.copernicus.eu
 export SH_AUTH_BASE_URL=https://identity.dataspace.copernicus.eu
-python -m src.utils.download_sentinel --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31
+python -m src.utils.download_sentinel \
+  --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31
 ```
+
+Use `--sh-base-url` and `--sh-auth-base-url` to override the service and
+authentication endpoints instead of the environment variables.
 
 ## `run_sentinel2_pipeline.sh`
 A helper script that runs the full Sentinel-2 workflow using the configuration

--- a/src/pipeline/download.py
+++ b/src/pipeline/download.py
@@ -8,9 +8,22 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Download Sentinel data using a config file")
     parser.add_argument("--config", required=True, help="Path to YAML config")
     parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument(
+        "--sh-base-url",
+        help="Sentinel Hub service URL (default: env SH_BASE_URL or Copernicus)",
+    )
+    parser.add_argument(
+        "--sh-auth-base-url",
+        help="Sentinel Hub auth URL (default: env SH_AUTH_BASE_URL or Copernicus)",
+    )
     args = parser.parse_args()
 
-    out_dir = download_sentinel.download_from_config(args.config, args.output)
+    out_dir = download_sentinel.download_from_config(
+        args.config,
+        args.output,
+        sh_base_url=args.sh_base_url,
+        sh_auth_base_url=args.sh_auth_base_url,
+    )
     shutil.copy(args.config, Path(out_dir) / Path(args.config).name)
 
 


### PR DESCRIPTION
## Summary
- add CLI options for sentinelhub URLs in `download_sentinel`
- propagate overrides through the pipeline downloader
- document the new flags in setup and scripts docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6846e766e7dc832089defdc9eb9a4680