### PR TITLE
Improve sentinelhub error handling

### DIFF
--- a/src/utils/download_sentinel.py
+++ b/src/utils/download_sentinel.py
@@ -19,6 +19,8 @@ from sentinelhub import (
     CRS,
     bbox_to_dimensions,
 )
+from oauthlib.oauth2.rfc6749.errors import InvalidClientError
+import sys
 
 
 def normalize_date(value: str) -> str:
@@ -112,9 +114,18 @@ def download_sentinel(
         (lon - buffer, lat - buffer, lon + buffer, lat + buffer), crs=CRS.WGS84
     )
     catalog = SentinelHubCatalog(config=config)
-    search = catalog.search(
-        DataCollection.SENTINEL2_L2A, bbox=bbox, time=(start, end), fields={"include": ["id"]}
-    )
+    try:
+        search = catalog.search(
+            DataCollection.SENTINEL2_L2A,
+            bbox=bbox,
+            time=(start, end),
+            fields={"include": ["id"]},
+        )
+    except InvalidClientError:
+        print(
+            "Authentication failed. Check SENTINELHUB_CLIENT_ID/SENTINELHUB_CLIENT_SECRET and base URLs."
+        )
+        sys.exit(1)
     if not list(search):
         print("No products found for given parameters")
         return out_dir
@@ -148,7 +159,13 @@ def download_sentinel(
             size=size,
             config=config,
         )
-        request.get_data(save_data=True)
+        try:
+            request.get_data(save_data=True)
+        except InvalidClientError:
+            print(
+                "Authentication failed. Check SENTINELHUB_CLIENT_ID/SENTINELHUB_CLIENT_SECRET and base URLs."
+            )
+            sys.exit(1)
         saved = Path(request.get_filename_list()[0])
         (out_dir / f"{band}.tif").write_bytes(saved.read_bytes())
         saved.unlink()


### PR DESCRIPTION
## Summary
- catch InvalidClientError when searching the Sentinel Hub catalog
- catch InvalidClientError when requesting data
- advise users to check credentials and URLs and exit on failure

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6846e76857f08320862d00daed2ab748