### PR TITLE
Enable bbox buffer via download.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,12 @@ python -m src.utils.download_sentinel \
   --lat 35.6 \
   --lon 139.7 \
   --start 2024-01-01 \
-  --end 2024-01-31
+  --end 2024-01-31 \
+  --buffer 0.005
 ```
+
+The `--buffer` option (or a `buffer` field in `download.yaml`) sets how wide the
+bounding box around the coordinate should be.
 
 If the target folder already exists the previously downloaded data will be
 reused.

--- a/configs/download.yaml
+++ b/configs/download.yaml
@@ -3,3 +3,4 @@ lon: 139.7
 start: '2024-01-01'
 end: '2024-01-31'
 satellite: 'Sentinel-2'
+buffer: 0.005

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,8 +32,12 @@ export SENTINELHUB_CLIENT_SECRET=<your client secret>
 export SH_BASE_URL=https://sh.dataspace.copernicus.eu
 export SH_AUTH_BASE_URL=https://identity.dataspace.copernicus.eu
 python -m src.utils.download_sentinel \
-  --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31
+  --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31 \
+  --buffer 0.005
 ```
+
+Specify `--buffer` or add a `buffer` field in a YAML config to control the
+width of the downloaded area in degrees.
 
 Use `--sh-base-url` and `--sh-auth-base-url` to override the service and
 authentication endpoints instead of the environment variables.

--- a/src/utils/download_sentinel.py
+++ b/src/utils/download_sentinel.py
@@ -57,6 +57,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--end", help="End date YYYY-MM-DD or YYYYMMDD")
     parser.add_argument("--satellite", default="Sentinel-2", help="Platform name")
     parser.add_argument("--output", help="Output directory")
+    parser.add_argument("--buffer", type=float, default=0.005, help="BBox buffer in degrees")
     parser.add_argument(
         "--sh-base-url",
         default=SH_BASE_URL,
@@ -78,6 +79,7 @@ def parse_args() -> argparse.Namespace:
         args.start = cfg["start"]
         args.end = cfg["end"]
         args.satellite = cfg.get("satellite", args.satellite)
+        args.buffer = cfg.get("buffer", args.buffer)
     if None in {args.lat, args.lon, args.start, args.end}:
         parser.error("lat, lon, start and end must be provided")
     return args
@@ -230,6 +232,7 @@ def download_from_config(
         start=cfg["start"],
         end=cfg["end"],
         satellite=cfg.get("satellite", "Sentinel-2"),
+        buffer=cfg.get("buffer", 0.005),
         out_dir=output_dir,
         sh_base_url=sh_base_url,
         sh_token_url=sh_token_url,
@@ -245,6 +248,7 @@ def main() -> None:
         args.end,
         args.satellite,
         args.output,
+        buffer=args.buffer,
         sh_base_url=args.sh_base_url,
         sh_token_url=args.sh_token_url,
     )


### PR DESCRIPTION
## Summary
- allow `buffer` param to be specified in `download.yaml`
- expose `--buffer` CLI option in `download_sentinel.py`
- document new argument in READMEs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6847d65a4c008320b8d2352542cd227f