### PR TITLE
Update Sentinel Hub auth variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ under `data/raw/<SATELLITE>` based on location and time range.
 export SENTINELHUB_CLIENT_ID=<your client id>
 export SENTINELHUB_CLIENT_SECRET=<your client secret>
 export SH_BASE_URL=https://sh.dataspace.copernicus.eu
-export SH_AUTH_BASE_URL=https://identity.dataspace.copernicus.eu
+export SH_TOKEN_URL=https://identity.dataspace.copernicus.eu
 python -m src.utils.download_sentinel \
   --lat 35.6 \
   --lon 139.7 \

--- a/docs/sentinelhub_setup.md
+++ b/docs/sentinelhub_setup.md
@@ -12,10 +12,10 @@ application to obtain a client ID and secret.
 export SENTINELHUB_CLIENT_ID=<your client id>
 export SENTINELHUB_CLIENT_SECRET=<your client secret>
 export SH_BASE_URL=https://sh.dataspace.copernicus.eu
-export SH_AUTH_BASE_URL=https://identity.dataspace.copernicus.eu
+export SH_TOKEN_URL=https://identity.dataspace.copernicus.eu
 ```
 
-Alternatively provide `--sh-base-url` and `--sh-auth-base-url` when running
+Alternatively provide `--sh-base-url` and `--sh-token-url` when running
 `download_sentinel.py` or the pipeline downloader to override these endpoints
 without setting environment variables.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,7 +30,7 @@ Example usage:
 export SENTINELHUB_CLIENT_ID=<your client id>
 export SENTINELHUB_CLIENT_SECRET=<your client secret>
 export SH_BASE_URL=https://sh.dataspace.copernicus.eu
-export SH_AUTH_BASE_URL=https://identity.dataspace.copernicus.eu
+export SH_TOKEN_URL=https://identity.dataspace.copernicus.eu
 python -m src.utils.download_sentinel \
   --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31 \
   --buffer 0.005
@@ -39,7 +39,7 @@ python -m src.utils.download_sentinel \
 Specify `--buffer` or add a `buffer` field in a YAML config to control the
 width of the downloaded area in degrees.
 
-Use `--sh-base-url` and `--sh-auth-base-url` to override the service and
+Use `--sh-base-url` and `--sh-token-url` to override the service and
 authentication endpoints instead of the environment variables.
 
 Pass the bands to download with `--bands` or a `bands:` array in the YAML


### PR DESCRIPTION
## Summary
- rename environment variable `SH_AUTH_BASE_URL` to `SH_TOKEN_URL`
- update CLI flag `--sh-auth-base-url` to `--sh-token-url`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentinelhub')*

------
https://chatgpt.com/codex/tasks/task_b_6847dea946088320b31f998a01161502