### PR TITLE
Add option to save Sentinel bands separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,14 @@ python -m src.utils.download_sentinel \
   --lon 139.7 \
   --start 2024-01-01 \
   --end 2024-01-31 \
-  --buffer 0.005
+  --buffer 0.005 \
+  --split-bands
 ```
 
 The `--buffer` option (or a `buffer` field in `download.yaml`) sets how wide the
-bounding box around the coordinate should be.
+bounding box around the coordinate should be. Add `--split-bands` (or set
+`split_bands: true` in `download.yaml`) to store each band as its own TIFF
+instead of the default `BANDS.tif` stack.
 
 If the target folder already exists the previously downloaded data will be
 reused.

--- a/configs/download.yaml
+++ b/configs/download.yaml
@@ -12,3 +12,4 @@ bands:
   - SCL
   - dataMask
 buffer: 0.03
+split_bands: false


### PR DESCRIPTION
## Summary
- allow `download_sentinel` to output per‑band files via `split_bands` flag
- expose flag on CLI and YAML config
- document the option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6847f7dd838c8320b8cf72ad328798d4