### PR TITLE
Switch to SCL-based cloud masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This project is licensed under the MIT License.
 
 ## 日本語の説明
 
-このプロジェクトはリモートセンシングデータを用いた簡単な分類ワークフローを示します。必要なデータは複数バンドのGeoTIFFと雲判定用のQAバンド、学習用ラベルです。
+このプロジェクトはリモートセンシングデータを用いた簡単な分類ワークフローを示します。必要なデータは複数バンドのGeoTIFFとSCL・dataMaskバンド、学習用ラベルです。
 
-1. `cloudmask.py` でQAバンドから雲マスクを作成します。
+1. `cloudmask.py` でSCL/dataMaskから雲マスクを作成します。
 2. `stack_bands.py` でマスクを適用したバンドスタックを作成します。
 3. `features.py` でNDVI・NDWIを計算します。
 4. `train_model.py` でRandomForest分類器を学習させます。
@@ -30,7 +30,7 @@ written by the pipeline can be kept under `data/processed/`.
 ## Sentinel-2 を用いた土地利用分類
 
 `data/raw/` フォルダに以下の Sentinel-2 バンド (`B02`, `B03`, `B04`, `B08`, `B11`) と
-QA バンド(`QA60`)、学習用ラベル(`labels.tif`) を配置します。
+シーン分類(`SCL`)・データマスク(`MASK`) バンド、学習用ラベル(`labels.tif`) を配置します。
 
 ```bash
 data/raw/
@@ -39,7 +39,8 @@ data/raw/
 ├── B04.tif
 ├── B08.tif
 ├── B11.tif
-├── QA60.tif
+├── SCL.tif
+├── MASK.tif
 └── labels.tif
 ```
 
@@ -50,7 +51,8 @@ data/raw/
 ```bash
 python -m src.classification.pipeline \
   --bands data/raw/B02.tif data/raw/B03.tif data/raw/B04.tif data/raw/B08.tif data/raw/B11.tif \
-  --qa data/raw/QA60.tif \
+  --scl data/raw/SCL.tif \
+  --mask data/raw/MASK.tif \
   --labels data/raw/labels.tif \
   --output outputs/prediction.tif
 ```
@@ -98,7 +100,7 @@ NumPy arrays only.
 ## Data requirements
 
 - Sentinel/Landsat like bands saved as individual GeoTIFF files
-- A QA band from which clouds can be detected
+- ``SCL`` and optional ``dataMask`` bands to detect clouds
 - A raster of training labels for model fitting
 
 ### Automated Sentinel‑2 download
@@ -141,7 +143,7 @@ creating an account and setting these variables.
 
 ## Usage
 
-1. Run `cloudmask.py` to derive a boolean mask of clouds from the QA band.
+1. Run `cloudmask.py` to derive a boolean mask of clouds from the SCL/dataMask bands.
 2. Use `stack_bands.py` to create a cloud-masked stack of bands.
 3. Compute NDVI and NDWI features with `features.py`.
 4. Train a RandomForest model using `train_model.py` and your label raster.

--- a/configs/preprocess.yaml
+++ b/configs/preprocess.yaml
@@ -4,5 +4,6 @@ bands:
   - data/raw/B04.tif
   - data/raw/B08.tif
   - data/raw/B11.tif
-qa: data/raw/QA60.tif
+scl: data/raw/SCL.tif
+mask: data/raw/MASK.tif
 features_out: data/processed/features.npz

--- a/src/classification/pipeline.py
+++ b/src/classification/pipeline.py
@@ -10,14 +10,23 @@ from .predict import predict_model
 
 def main():
     parser = argparse.ArgumentParser(description="Sentinel-2 land use classification pipeline")
-    parser.add_argument("--bands", nargs=5, metavar="BAND", help="Paths to Sentinel-2 bands (B02,B03,B04,B08,B11)")
-    parser.add_argument("--qa", required=True, help="Path to QA band for cloud masking")
+    parser.add_argument(
+        "--bands",
+        nargs=5,
+        metavar="BAND",
+        help="Paths to Sentinel-2 bands (B02,B03,B04,B08,B11)",
+    )
+    parser.add_argument("--scl", required=True, help="Path to SCL scene classification band")
+    parser.add_argument(
+        "--mask",
+        help="Optional dataMask band where 0 denotes invalid pixels",
+    )
     parser.add_argument("--labels", required=True, help="Raster path with training labels")
     parser.add_argument("--output", default="outputs/prediction.tif", help="Output path for classification result")
     parser.add_argument("--n_estimators", type=int, default=100, help="Number of trees for RandomForest")
     args = parser.parse_args()
 
-    mask = cloud_mask(args.qa)
+    mask = cloud_mask(args.scl, args.mask)
     stack, meta = stack_bands(args.bands, mask)
 
     # Sentinel-2 indices: provided order is B02, B03, B04, B08, B11

--- a/src/pipeline/preprocess.py
+++ b/src/pipeline/preprocess.py
@@ -38,18 +38,19 @@ def main() -> None:
         spectral = [b for b in dl_cfg.get("bands", []) if b not in {"SCL", "dataMask"}]
         bands = [input_dir / f"{b}.tif" for b in spectral]
         if "SCL" in dl_cfg.get("bands", []):
-            qa_name = "SCL.tif"
-        elif "dataMask" in dl_cfg.get("bands", []):
-            qa_name = "MASK.tif"
+            scl_path = input_dir / "SCL.tif"
         else:
-            qa_name = Path(cfg["qa"]).name
-
-        qa_path = input_dir / qa_name
+            scl_path = input_dir / Path(cfg["scl"]).name
+        if "dataMask" in dl_cfg.get("bands", []):
+            mask_path = input_dir / "MASK.tif"
+        else:
+            mask_path = input_dir / Path(cfg.get("mask", "")).name if cfg.get("mask") else None
     else:
         bands = [input_dir / Path(p).name for p in cfg["bands"]]
-        qa_path = input_dir / Path(cfg["qa"]).name
+        scl_path = input_dir / Path(cfg["scl"]).name
+        mask_path = input_dir / Path(cfg.get("mask", "")).name if cfg.get("mask") else None
 
-    mask = cloud_mask(qa_path)
+    mask = cloud_mask(scl_path, mask_path)
     stack, meta = stack_bands(bands, mask)
     features = compute_features(stack, red_idx=2, nir_idx=3, swir_idx=4)
 

--- a/src/preprocess/cloudmask.py
+++ b/src/preprocess/cloudmask.py
@@ -2,24 +2,28 @@ import numpy as np
 import rasterio
 
 
-def cloud_mask(qa_path, cloud_bits=(3, 5)):
-    """Derive a boolean cloud mask from a QA band.
+def cloud_mask(scl_path, mask_path=None, cloudy_values=(3, 7, 8, 9, 10, 11)):
+    """Return a boolean cloud mask from Sentinel‑2 ``SCL``/``dataMask`` bands.
 
     Parameters
     ----------
-    qa_path : str
-        Path to QA band raster.
-    cloud_bits : tuple of int
-        Bit positions indicating cloud information.
+    scl_path : str
+        Path to the ``SCL`` scene classification band.
+    mask_path : str, optional
+        Optional ``dataMask`` band where 0 denotes invalid pixels.
+    cloudy_values : tuple of int
+        ``SCL`` values treated as cloudy. Defaults to shadow and cloud classes.
 
     Returns
     -------
     numpy.ndarray
-        Boolean array where True indicates cloud pixels.
+        Boolean array where ``True`` indicates cloud or invalid pixels.
     """
-    with rasterio.open(qa_path) as src:
-        qa = src.read(1)
-    mask = np.zeros_like(qa, dtype=bool)
-    for bit in cloud_bits:
-        mask |= (qa & (1 << bit)) > 0
+    with rasterio.open(scl_path) as src:
+        scl = src.read(1)
+    mask = np.isin(scl, cloudy_values)
+    if mask_path:
+        with rasterio.open(mask_path) as src:
+            data_mask = src.read(1)
+        mask |= data_mask == 0
     return mask

--- a/src/utils/download_sentinel.py
+++ b/src/utils/download_sentinel.py
@@ -33,6 +33,7 @@ DEFALUT_BANDS = ["B02", "B03", "B04", "B08", "B11", "SCL", "dataMask"] # Sentine
 # SCL is L2A scene classification
 # CLP is L2A cloud probability.but not available in L2A CDSE
 # dataMask is L2A data mask (valid pixels)
+# This repository derives cloud masks from the SCL and dataMask bands.
 
 def normalize_date(value: str) -> str:
     """Return date in YYYY-MM-DD format."""


### PR DESCRIPTION
## Summary
- derive cloud mask from SCL and dataMask bands
- update preprocessing configuration
- adjust CLI to accept SCL and dataMask
- refresh README for new workflow
- clarify Sentinel download defaults

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684bd2a4fa4c83208d88bd54a4852c5b