### PR TITLE
Add default output dir for preprocess

### DIFF
--- a/src/pipeline/preprocess.py
+++ b/src/pipeline/preprocess.py
@@ -44,14 +44,18 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Preprocess Sentinel bands")
     parser.add_argument("--config", required=True, help="YAML config file")
     parser.add_argument("--input-dir", required=True, help="Directory with raw bands")
-    parser.add_argument("--output-dir", required=True, help="Directory for features")
+    parser.add_argument("--output-dir", help="Directory for features")
     args = parser.parse_args()
 
     with open(args.config) as f:
         cfg = yaml.safe_load(f)
 
     input_dir = Path(args.input_dir)
-    output_dir = Path(args.output_dir)
+    if args.output_dir:
+        output_dir = Path(args.output_dir)
+    else:
+        output_dir = input_dir / "preprocess"
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     dl_cfg_path = input_dir / "download.yaml"
     if dl_cfg_path.exists():


### PR DESCRIPTION
## Summary
- make `--output-dir` optional for preprocessing step
- default to `INPUT_DIR/preprocess` when not provided

## Testing
- `python -m py_compile src/pipeline/preprocess.py`


------
https://chatgpt.com/codex/tasks/task_b_684fd7b60b44832095564598a8b1a738