### PR TITLE
Fix train script path mismatch

### DIFF
--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -1,3 +1,4 @@
-features: data/processed/features.npz
+# The features file is expected inside the directory passed to `--features-dir`.
+features: features.npz
 model: outputs/model.pkl
 output: outputs/prediction.tif

--- a/configs/preprocess.yaml
+++ b/configs/preprocess.yaml
@@ -6,4 +6,6 @@ bands:
   - data/raw/B11.tif
 scl: data/raw/SCL.tif
 mask: data/raw/MASK.tif
-features_out: data/processed/features.npz
+# Only the base name of this path is used; the file is written under the
+# `preprocess` directory of the input data.
+features_out: features.npz

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,4 +1,6 @@
-features: data/processed/features.npz
+# Only the file name is used by the training script; the directory is provided
+# separately via the `--input-dir` option.
+features: features.npz
 labels: data/raw/labels.tif
 model_out: outputs/model.pkl
 n_estimators: 100

--- a/scripts/train_model.sh
+++ b/scripts/train_model.sh
@@ -5,10 +5,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Hard coded paths for a single example run
-INPUT_DIR="data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31"
+RAW_DIR="data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31"
+# The preprocessing step writes features into a `preprocess` subfolder of the
+# raw download directory. Point the trainer to that directory so it can locate
+# `features.npz`.
+FEATURES_DIR="$RAW_DIR/preprocess"
 OUTPUT_DIR="outputs/model_example"
 CONFIG="configs/train.yaml"
 
 python -m src.pipeline.train --config "$CONFIG" \
-    --input-dir "$INPUT_DIR" --output-dir "$OUTPUT_DIR"
+    --input-dir "$FEATURES_DIR" --output-dir "$OUTPUT_DIR"
 


### PR DESCRIPTION
## Summary
- adjust `train_model.sh` to point at preprocess output
- clarify config files to only store feature filenames

## Testing
- `bash -n scripts/train_model.sh`
- `python -m py_compile src/pipeline/train.py`
- `shellcheck scripts/train_model.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852162af3f88320be605eb623ab23c1