### PR TITLE
Update WorldCover download logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,7 @@ bash scripts/worldcover_to_labels.sh
 ```
 
 `worldcover_to_labels.sh` は `src/utils/worldcover_to_labels.py` を呼び出し、
-WorldCover タイルが見つからなければダウンロードしてから
-=======
-以下は 2021 年版タイルをダウンロードし、Sentinel-2 バンドと同じ範囲に切り出して
-`labels.tif` を作成する例です。
-
-```bash
-wget -P data/worldcover \
-  https://esa-worldcover.s3.amazonaws.com/v100/2021/map/ESA_WorldCover_10m_2021_v100_Map.tif
-bash scripts/worldcover_to_labels.sh
-```
-
-`worldcover_to_labels.sh` は `src/utils/worldcover_to_labels.py` を呼び出して
+WorldCover タイルが見つからなければ ZIP アーカイブを自動ダウンロードして展開し、
 `data/raw/B02.tif` と同じ範囲・解像度にリサンプリングした `data/raw/labels.tif`
 を生成します。
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -64,6 +64,6 @@ bash scripts/run_sentinel2_pipeline.sh
 ## `worldcover_to_labels.sh`
 Crops an ESA WorldCover tile to the area covered by the example
 Sentinel‑2 scene. The script invokes `src/utils/worldcover_to_labels.py`, which
-downloads the WorldCover data if it is missing and then produces
+downloads and extracts the WorldCover ZIP if it is missing and then produces
 
 `data/raw/labels.tif` matching the resolution of the reference band.

--- a/scripts/worldcover_to_labels.sh
+++ b/scripts/worldcover_to_labels.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 
-# Example paths. WORLD_COVER will be downloaded if it does not already exist.
+# Example paths. The WorldCover ZIP will be downloaded and extracted if missing.
 
 WORLD_COVER="data/worldcover/ESA_WorldCover_10m_2021_v100_Map.tif"
 REFERENCE="data/raw/B02.tif"

--- a/src/utils/worldcover_to_labels.py
+++ b/src/utils/worldcover_to_labels.py
@@ -9,6 +9,9 @@ import rasterio
 from rasterio.warp import reproject, Resampling
 import numpy as np
 from urllib.request import urlretrieve
+import tempfile
+import zipfile
+import shutil
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Clip WorldCover to target raster")
@@ -21,8 +24,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--output", required=True, help="Output labels.tif path")
     p.add_argument(
         "--url",
-        default="https://esa-worldcover.s3.amazonaws.com/v100/2021/map/ESA_WorldCover_10m_2021_v100_Map.tif",
-        help="Source URL for WorldCover when downloading",
+        default="https://esa-worldcover.s3.amazonaws.com/v100/2021/map/ESA_WorldCover_10m_2021_v100_Map.zip",
+        help="ZIP URL for WorldCover when downloading",
     )
 
     return p.parse_args()
@@ -33,9 +36,27 @@ def main() -> None:
 
     wc_path = Path(args.worldcover)
     if not wc_path.exists():
-        print(f"Downloading WorldCover data to {wc_path}")
+        print(f"Downloading WorldCover data from {args.url}")
         wc_path.parent.mkdir(parents=True, exist_ok=True)
-        urlretrieve(args.url, wc_path)
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                zip_path = Path(tmpdir) / Path(args.url).name
+                urlretrieve(args.url, zip_path)
+                with zipfile.ZipFile(zip_path) as zf:
+                    tif_member = None
+                    for name in zf.namelist():
+                        if name.lower().endswith('.tif'):
+                            tif_member = name
+                            break
+                    if tif_member is None:
+                        raise RuntimeError('TIFF not found in ZIP archive')
+                    zf.extract(tif_member, path=tmpdir)
+                    shutil.move(Path(tmpdir) / tif_member, wc_path)
+        except Exception as e:
+            raise RuntimeError(
+                'Failed to download or extract WorldCover dataset. '
+                'Verify the URL or supply --url.'
+            ) from e
     args.worldcover = str(wc_path)
 
     with rasterio.open(args.reference) as ref:


### PR DESCRIPTION
## Summary
- download the WorldCover 2021 dataset from the ZIP archive
- unpack the TIFF and clean up temporary ZIP
- clarify download step in worldcover_to_labels.sh and docs

## Testing
- `python -m py_compile src/utils/worldcover_to_labels.py`

------
https://chatgpt.com/codex/tasks/task_b_68522cecd5e0832084969e1d63e3e628