### PR TITLE
Update WorldCover handling to v200 tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,9 @@ bash scripts/worldcover_to_labels.sh
 ```
 
 `worldcover_to_labels.sh` は `src/utils/worldcover_to_labels.py` を呼び出し、
-
-WorldCover タイルが見つからなければ ZIP をダウンロードして展開し
-`data/raw/B02.tif` と同じ範囲・解像度にリサンプリングした `data/raw/labels.tif`
-を生成します。
+必要な WorldCover タイルが存在しなければ自動的にダウンロードして
+`data/raw/B02.tif` と同じ範囲・解像度にリサンプリングした
+`data/raw/labels.tif` を生成します。
 
 ### 3. Sentinel-2 土地利用分類の実行と表示
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -64,7 +64,6 @@ bash scripts/run_sentinel2_pipeline.sh
 ## `worldcover_to_labels.sh`
 Crops an ESA WorldCover tile to the area covered by the example
 Sentinel‑2 scene. The script invokes `src/utils/worldcover_to_labels.py`, which
-downloads a ZIP archive of the WorldCover data if it is missing, extracts it,
-and then produces
+downloads the required WorldCover tiles on demand and then produces
 
 `data/raw/labels.tif` matching the resolution of the reference band.

--- a/scripts/worldcover_to_labels.sh
+++ b/scripts/worldcover_to_labels.sh
@@ -6,14 +6,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 
 
-# Example paths. WORLD_COVER will be downloaded as a ZIP archive and
-# extracted if the TIFF does not already exist.
+# Example paths. The required WorldCover tile will be downloaded if missing.
 
-WORLD_COVER="data/worldcover/ESA_WorldCover_10m_2021_v100_Map.tif"
+WORLD_COVER_DIR="data/worldcover"
+TILE="N35E139"
 REFERENCE="data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31/B02.tif"
 OUTPUT="data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31/labels.tif"
 
 python -m src.utils.worldcover_to_labels \
-    --worldcover "$WORLD_COVER" \
+    --worldcover-dir "$WORLD_COVER_DIR" \
+    --tile "$TILE" \
     --reference "$REFERENCE" \
     --output "$OUTPUT"


### PR DESCRIPTION
## Summary
- update worldcover scripts to default to v200 tile downloads
- support tile or bounding box download in `worldcover_to_labels.py`
- adjust helper script to use tile download
- clarify docs for new behavior

## Testing
- `python -m py_compile src/utils/worldcover_to_labels.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentinelhub')*

------
https://chatgpt.com/codex/tasks/task_b_685255b041648320a2366a3742ff3eec