### PR TITLE
Update WorldCover download helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,17 @@ data/raw/
 このファイルはリポジトリには含まれていません。ユーザー自身で作成するか外部ソースから入手してください。
 外部ソースから入手する場合は次の「WorldCover からラベルを作成する」を参照してください。
 
-#### WorldCover からラベルを作成する
+#### WorldCover タイルをダウンロードする
 
-ESA の **WorldCover** データセットを利用すると簡易的な土地利用ラベルを取得できます。
-以下は このデータセットをダウンロードしていない場合は自動取得し、
-Sentinel-2 バンドと同じ範囲に切り出して `labels.tif` を作成する例です。
+ESA の **WorldCover** データセットの一部を取得する例として、
+`scripts/worldcover_to_labels.sh` は `src/utils/download_worldcover_datasets.py` を
+呼び出します。デフォルトでは九州周辺をカバーする緯度経度範囲
+`30 129 34 132` を指定し、2021 年版 (`v200/2021/map/`) のタイルを
+`data/wc2021_kyusyu_bbox` 以下に保存します。
 
 ```bash
 bash scripts/worldcover_to_labels.sh
 ```
-
-`worldcover_to_labels.sh` は `src/utils/worldcover_to_labels.py` を呼び出し、
-必要な WorldCover タイルが存在しなければ自動的にダウンロードして
-`data/raw/B02.tif` と同じ範囲・解像度にリサンプリングした
-`data/raw/labels.tif` を生成します。
 
 #### WorldCover タイルだけを取得する
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,8 +62,7 @@ bash scripts/run_sentinel2_pipeline.sh
 ```
 
 ## `worldcover_to_labels.sh`
-Crops an ESA WorldCover tile to the area covered by the example
-Sentinel‑2 scene. The script invokes `src/utils/worldcover_to_labels.py`, which
-downloads the required WorldCover tiles on demand and then produces
-
-`data/raw/labels.tif` matching the resolution of the reference band.
+Downloads ESA WorldCover tiles using `src/utils/download_worldcover_datasets.py`.
+The default parameters fetch 2021 tiles covering the Kyushu region of Japan
+(`--bbox 30 129 34 132 --version v200/2021/map/`) and store them under
+`data/wc2021_kyusyu_bbox`.

--- a/scripts/worldcover_to_labels.sh
+++ b/scripts/worldcover_to_labels.sh
@@ -6,15 +6,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 
 
-# Example paths. The required WorldCover tile will be downloaded if missing.
+# Example options for downloading WorldCover tiles.
+# The selected bounding box roughly covers the Kyushu area of Japan.
 
-WORLD_COVER_DIR="data/worldcover"
-TILE="N35E139"
-REFERENCE="data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31/B02.tif"
-OUTPUT="data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31/labels.tif"
-
-python -m src.utils.worldcover_to_labels \
-    --worldcover-dir "$WORLD_COVER_DIR" \
-    --tile "$TILE" \
-    --reference "$REFERENCE" \
-    --output "$OUTPUT"
+python -m src.utils.download_worldcover_datasets \
+    --bbox 30 129 34 132 \
+    --output "data/wc2021_kyusyu_bbox" \
+    --version v200/2021/map/


### PR DESCRIPTION
## Summary
- repurpose `worldcover_to_labels.sh` to download Kyushu WorldCover tiles
- update README sections to explain the new behaviour
- clarify script usage in `scripts/README.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68539938cd2883208dcac81d36ef56ee