### PR TITLE
Keep split and stacked Sentinel downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,12 @@ python -m src.utils.download_sentinel \
   --lon 139.7 \
   --start 2024-01-01 \
   --end 2024-01-31 \
-  --buffer 0.005 \
-  --split-bands
+  --buffer 0.005 
 ```
 
 The `--buffer` option (or a `buffer` field in `download.yaml`) sets how wide the
-bounding box around the coordinate should be. Add `--split-bands` (or set
-`split_bands: true` in `download.yaml`) to store each band as its own TIFF
-instead of the default `BANDS.tif` stack.
+bounding box around the coordinate should be. Downloaded images are saved as a
+multi-band `BANDS.tif` file and also split into individual band TIFFs.
 
 If the target folder already exists the previously downloaded data will be
 reused.

--- a/configs/download.yaml
+++ b/configs/download.yaml
@@ -12,4 +12,3 @@ bands:
   - SCL
   - dataMask
 buffer: 0.03
-split_bands: true

--- a/src/pipeline/preprocess.py
+++ b/src/pipeline/preprocess.py
@@ -48,15 +48,13 @@ def main() -> None:
             dl_cfg = yaml.safe_load(f)
 
         spectral = [b for b in dl_cfg.get("bands", []) if b not in {"SCL", "dataMask"}]
-        if not dl_cfg.get("split_bands", False):
-            stack = input_dir / "BANDS.tif"
-            if stack.exists():
+        stack = input_dir / "BANDS.tif"
+        if stack.exists():
+            missing = [b for b in spectral if not (input_dir / f"{b}.tif").exists()]
+            if missing:
                 split_band_stack(stack, spectral)
-                dl_cfg["split_bands"] = True
-            else:
-                raise ValueError(
-                    "split_bands must be true when preprocessing downloaded data"
-                )
+        else:
+            raise ValueError("BANDS.tif not found in input directory")
 
         bands = [input_dir / f"{b}.tif" for b in spectral]
         if "SCL" in dl_cfg.get("bands", []):


### PR DESCRIPTION
## Summary
- remove the `split_bands` option from configuration and CLI
- store a multi-band `BANDS.tif` and also split out band TIFFs automatically
- adapt preprocessing to always expect both forms
- update example configuration and documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6853c755f00c8320901b57efdc17347f