### PR TITLE
Add cloud filter and per-scene download

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,16 @@ python -m src.utils.download_sentinel \
   --lon 139.7 \
   --start 2024-01-01 \
   --end 2024-01-31 \
-  --buffer 0.005 
+  --buffer 0.005
+  --max-cloud 20
 ```
 
 The `--buffer` option (or a `buffer` field in `download.yaml`) sets how wide the
 bounding box around the coordinate should be. Downloaded images are saved as a
 multi-band `BANDS.tif` file and also split into individual band TIFFs.
+
+Use `--max-cloud` or `max_cloud:` in `download.yaml` to limit the catalog search
+to scenes with less than the specified cloud cover percentage.
 
 If the target folder already exists the previously downloaded data will be
 reused.

--- a/configs/download.yaml
+++ b/configs/download.yaml
@@ -2,6 +2,7 @@ lat: 35.6
 lon: 139.7
 start: '2024-01-01'
 end: '2024-01-31'
+max_cloud: 20
 satellite: 'Sentinel-2'
 bands:
   - B02

--- a/docs/sentinelhub_setup.md
+++ b/docs/sentinelhub_setup.md
@@ -23,6 +23,8 @@ location and date range. For instance the example scripts store files in
 the original `download.yaml` which the preprocessing step reads back to locate
 the bands. Requests are sent to `https://sh.dataspace.copernicus.eu`. If the
 directory already exists the cached files will be reused.
+Specify `max_cloud` in the YAML (or `--max-cloud` via CLI) to only download
+scenes below that cloud cover percentage.
 
 > **Note**
 > Network access to `sh.dataspace.copernicus.eu` is required. Configure a proxy

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,10 +38,13 @@ export SH_TOKEN_URL=https://identity.dataspace.copernicus.eu
 python -m src.utils.download_sentinel \
   --lat 35.6 --lon 139.7 --start 2024-01-01 --end 2024-01-31 \
   --buffer 0.005
+  --max-cloud 20
 ```
 
 Specify `--buffer` or add a `buffer` field in a YAML config to control the
 width of the downloaded area in degrees.
+Use `--max-cloud` or `max_cloud:` in the YAML to filter scenes by cloud
+percentage.
 
 Use `--sh-base-url` and `--sh-token-url` to override the service and
 authentication endpoints instead of the environment variables.


### PR DESCRIPTION
## Summary
- add `max_cloud` field in download config and CLI
- filter Sentinel Hub catalog by cloud cover and create date folders for each scene
- document the new option in README and scripts docs
- mention cloud filtering in Sentinel Hub setup guide

## Testing
- `python -m py_compile src/utils/download_sentinel.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentinelhub')*

------
https://chatgpt.com/codex/tasks/task_b_6853cc17502c8320af58ac041f6682a7