### PR TITLE
Improve download filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ multi-band `BANDS.tif` file and also split into individual band TIFFs.
 
 Use `--max-cloud` or `max_cloud:` in `download.yaml` to limit the catalog search
 to scenes with less than the specified cloud cover percentage.
+Use `--min-valid` or `min_valid:` in `download.yaml` to skip scenes where less
+than that percentage of pixels are marked valid by the `dataMask` band.
 
 If the target folder already exists the previously downloaded data will be
 reused.

--- a/configs/download.yaml
+++ b/configs/download.yaml
@@ -3,6 +3,7 @@ lon: 139.7
 start: '2024-01-01'
 end: '2024-01-31'
 max_cloud: 20
+min_valid: 20
 satellite: 'Sentinel-2'
 bands:
   - B02


### PR DESCRIPTION
## Summary
- filter out scenes with too many invalid pixels
- expose `min-valid` CLI flag and config option
- document the new option

## Testing
- `python -m py_compile src/utils/download_sentinel.py`
- `python -m py_compile src/utils/sentinelhub_test.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentinelhub')*

------
https://chatgpt.com/codex/tasks/task_b_6853dcd2b6b08320b5d66a853a2c55f4