### PR TITLE
Implement cloud-masked mosaic in download pipeline

### DIFF
--- a/src/pipeline/download.py
+++ b/src/pipeline/download.py
@@ -7,6 +7,7 @@ from ..utils.download_sentinel import (
     SH_TOKEN_URL,
 )
 from ..utils.mosaic import mosaic_sentinel_directory
+from ..utils.cloud_free import apply_cloud_mask_to_directory
 
 
 def main() -> None:
@@ -33,6 +34,8 @@ def main() -> None:
         sh_base_url=args.sh_base_url,
         sh_token_url=args.sh_token_url,
     )
+    # Remove cloudy pixels in each scene before mosaicking
+    apply_cloud_mask_to_directory(Path(out_dir))
     shutil.copy(args.config, Path(out_dir) / Path(args.config).name)
 
     # Mosaic all downloaded scenes into a single stack

--- a/src/utils/cloud_free.py
+++ b/src/utils/cloud_free.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import rasterio
+
+from ..preprocess.cloudmask import cloud_mask
+
+
+def apply_cloud_mask(scene_dir: Path) -> None:
+    """Mask cloudy pixels in all band files of a scene folder."""
+    band_stack = scene_dir / "BANDS.tif"
+    scl_file = scene_dir / "SCL.tif"
+    mask_file = scene_dir / "MASK.tif"
+
+    if not band_stack.exists() or not scl_file.exists():
+        return
+
+    mask = cloud_mask(scl_file, mask_file if mask_file.exists() else None)
+
+    with rasterio.open(band_stack) as src:
+        data = src.read().astype("float32")
+        meta = src.meta.copy()
+    data[:, mask] = -9999.0
+    meta.update(dtype="float32", nodata=-9999.0)
+    tmp = scene_dir / "BANDS.tmp.tif"
+    with rasterio.open(tmp, "w", **meta) as dst:
+        dst.write(data)
+    tmp.replace(band_stack)
+
+    for band_file in scene_dir.glob("B??.tif"):
+        if band_file.name in {"SCL.tif", "MASK.tif"}:
+            continue
+        with rasterio.open(band_file) as src:
+            arr = src.read(1).astype("float32")
+            meta = src.meta.copy()
+        arr[mask] = -9999.0
+        meta.update(dtype="float32", nodata=-9999.0)
+        tmp_band = band_file.with_suffix(".tmp.tif")
+        with rasterio.open(tmp_band, "w", **meta) as dst:
+            dst.write(arr, 1)
+        tmp_band.replace(band_file)
+
+
+def apply_cloud_mask_to_directory(out_dir: Path) -> None:
+    """Apply cloud masking to all dated subfolders."""
+    for sub in out_dir.iterdir():
+        if sub.is_dir():
+            apply_cloud_mask(sub)


### PR DESCRIPTION
## Summary
- add `cloud_free` helper module to mask Sentinel scenes using SCL
- apply cloud masking to each downloaded scene before mosaicking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854ac00e8d4832082e9995acba590c6