### PR TITLE
Refactor download workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Individual steps can also be executed via the helper scripts in `scripts/`:
 
 ```bash
 bash scripts/download_sentinel2.sh
+bash scripts/cloud_free_sentinel2.sh
+bash scripts/mosaic_sentinel2.sh
 bash scripts/preprocess_sentinel2.sh
 bash scripts/train_model.sh
 bash scripts/predict_sentinel2.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -59,6 +59,12 @@ download folder after all scenes are retrieved. Use
 `src/utils/mosaic_scenes.py` on the extracted archive to merge the dated
 subfolders back into single-band images.
 
+## `cloud_free_sentinel2.sh` and `mosaic_sentinel2.sh`
+After downloading scenes you can remove cloudy pixels in each dated folder with
+`cloud_free_sentinel2.sh`. The script invokes `src.pipeline.cloud_free` on the
+download directory. Afterwards combine all dates into a single stack with
+`mosaic_sentinel2.sh` which runs `src.pipeline.mosaic`.
+
 ## `run_sentinel2_pipeline.sh`
 A helper script that runs the full Sentinel-2 workflow using the configuration
 files stored in `configs/`. Each pipeline step copies its YAML configuration

--- a/scripts/cloud_free_sentinel2.sh
+++ b/scripts/cloud_free_sentinel2.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Match the directory created by the download step
+RAW_DIR="data/raw/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31"
+
+python -m src.pipeline.cloud_free --input-dir "$RAW_DIR"

--- a/scripts/mosaic_sentinel2.sh
+++ b/scripts/mosaic_sentinel2.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Match the directory created by the download step
+RAW_DIR="data/raw/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31"
+
+python -m src.pipeline.mosaic --input-dir "$RAW_DIR" --method best

--- a/scripts/run_sentinel2_pipeline.sh
+++ b/scripts/run_sentinel2_pipeline.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Simply invoke each helper script which defines its own paths
 bash "$SCRIPT_DIR/download_sentinel2.sh"
+bash "$SCRIPT_DIR/cloud_free_sentinel2.sh"
+bash "$SCRIPT_DIR/mosaic_sentinel2.sh"
 bash "$SCRIPT_DIR/preprocess_sentinel2.sh"
 bash "$SCRIPT_DIR/worldcover_to_labels.sh"
 bash "$SCRIPT_DIR/train_model.sh"

--- a/src/pipeline/cloud_free.py
+++ b/src/pipeline/cloud_free.py
@@ -1,0 +1,20 @@
+import argparse
+from pathlib import Path
+
+from ..utils.cloud_free import apply_cloud_mask_to_directory
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Remove cloudy pixels from each dated Sentinel-2 folder"
+    )
+    parser.add_argument(
+        "--input-dir", required=True, help="Directory containing dated scenes"
+    )
+    args = parser.parse_args()
+
+    apply_cloud_mask_to_directory(Path(args.input_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipeline/download.py
+++ b/src/pipeline/download.py
@@ -6,8 +6,7 @@ from ..utils.download_sentinel import (
     SH_BASE_URL,
     SH_TOKEN_URL,
 )
-from ..utils.mosaic import mosaic_sentinel_directory
-from ..utils.cloud_free import apply_cloud_mask_to_directory
+
 
 
 def main() -> None:
@@ -26,12 +25,6 @@ def main() -> None:
         type=str,
         help="Sentinel Hub auth URL",
     )
-    parser.add_argument(
-        "--mosaic-method",
-        default="best",
-        choices=["best", "median"],
-        help="Pixel compositing method when mosaicking scenes",
-    )
     args = parser.parse_args()
 
     out_dir = download_from_config(
@@ -40,12 +33,7 @@ def main() -> None:
         sh_base_url=args.sh_base_url,
         sh_token_url=args.sh_token_url,
     )
-    # Remove cloudy pixels in each scene before mosaicking
-    apply_cloud_mask_to_directory(Path(out_dir))
     shutil.copy(args.config, Path(out_dir) / Path(args.config).name)
-
-    # Mosaic all downloaded scenes into a single stack
-    mosaic_sentinel_directory(Path(out_dir), method=args.mosaic_method)
 
 
 if __name__ == "__main__":

--- a/src/pipeline/mosaic.py
+++ b/src/pipeline/mosaic.py
@@ -1,0 +1,24 @@
+import argparse
+from pathlib import Path
+
+from ..utils.mosaic import mosaic_sentinel_directory
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Mosaic dated Sentinel-2 folders into a single stack"
+    )
+    parser.add_argument(
+        "--input-dir", required=True, help="Directory containing dated scenes"
+    )
+    parser.add_argument(
+        "--method", default="best", choices=["best", "median"],
+        help="Pixel compositing strategy"
+    )
+    args = parser.parse_args()
+
+    mosaic_sentinel_directory(Path(args.input_dir), method=args.method)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- keep `download.py` focused on grabbing scenes
- expose cloud masking and mosaic steps as new CLI modules
- add helper scripts to run the new commands
- update pipeline runner and documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6854bca7a7c88320b4b32d6c4a8eb25f