### PR TITLE
Improve nodata handling in WorldCover labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ WorldCover タイルから `labels.tif` を切り出すには
 `src.utils.worldcover_to_label` を利用します。`--worldcover` にタイルを保存した
 ディレクトリ、`--sentinel-dir` に `download.yaml` を含む Sentinel‑2 のダウンロード
 フォルダを指定してください。
+このスクリプトは指定範囲と重なるタイルのみを読み込むため、タイルが多い場合もメモリ使用量を抑えられます。
 
 ```bash
 python -m src.utils.worldcover_to_label \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,7 +84,9 @@ The default parameters fetch 2021 tiles covering the Kyushu region of Japan
 ## `worldcover_to_label.py`
 Cropping the downloaded tiles to match a Sentinel‑2 scene can be done with the
 `src.utils.worldcover_to_label` command. Provide the tile directory and the
-Sentinel download folder containing `download.yaml`:
+Sentinel download folder containing `download.yaml`. The script loads only
+tiles overlapping the requested area, reducing memory usage when many tiles are
+present:
 
 ```bash
 python -m src.utils.worldcover_to_label \

--- a/src/utils/worldcover_to_label.py
+++ b/src/utils/worldcover_to_label.py
@@ -24,6 +24,7 @@ import rasterio
 from rasterio.merge import merge
 from rasterio.warp import reproject, Resampling
 from rasterio.windows import from_bounds
+from rasterio.coords import disjoint_bounds
 
 
 def parse_bbox(cfg: dict) -> tuple[float, float, float, float]:
@@ -50,7 +51,8 @@ def load_reference_meta(sentinel_dir: Path, cfg: dict) -> dict:
         path = tiffs[0]
     with rasterio.open(path) as src:
         meta = src.meta.copy()
-    meta.update(count=1, dtype="uint8")
+    # Ensure nodata is valid for uint8 output
+    meta.update(count=1, dtype="uint8", nodata=0)
     return meta
 
 
@@ -83,8 +85,22 @@ def main() -> None:
     wc_files = sorted(wc_dir.glob("*.tif"))
     if not wc_files:
         raise FileNotFoundError(f"No WorldCover tiles found in {wc_dir}")
-    srcs = [rasterio.open(fp) for fp in wc_files]
-    mosaic, transform = merge(srcs)
+
+    bbox_bounds = bbox
+    srcs: list[rasterio.io.DatasetReader] = []
+    for fp in wc_files:
+        src = rasterio.open(fp)
+        if disjoint_bounds(src.bounds, bbox_bounds):
+            src.close()
+        else:
+            srcs.append(src)
+
+    if not srcs:
+        raise RuntimeError(
+            f"No WorldCover tiles intersect bounding box {bbox_bounds}"
+        )
+
+    mosaic, transform = merge(srcs, bounds=bbox_bounds)
     for src in srcs:
         src.close()
 


### PR DESCRIPTION
## Summary
- ensure uint8 nodata value is valid in `worldcover_to_label.py`

## Testing
- `python -m py_compile src/utils/worldcover_to_label.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6854cad824108320adf9fcf18f1abdf5