### PR TITLE
Fix output config filename for download step

### DIFF
--- a/src/pipeline/download.py
+++ b/src/pipeline/download.py
@@ -33,7 +33,9 @@ def main() -> None:
         sh_base_url=args.sh_base_url,
         sh_token_url=args.sh_token_url,
     )
-    shutil.copy(args.config, Path(out_dir) / Path(args.config).name)
+    # Later pipeline stages expect the config file to be named
+    # ``download.yaml`` inside the download directory.
+    shutil.copy(args.config, Path(out_dir) / "download.yaml")
 
 
 if __name__ == "__main__":

--- a/src/utils/download_sentinel.py
+++ b/src/utils/download_sentinel.py
@@ -333,7 +333,9 @@ def main() -> None:
         zip_output=args.zip_output,
     )
     if args.config:
-        shutil.copy(args.config, Path(out_dir) / Path(args.config).name)
+        # Store the configuration under a standard name so other
+        # commands can easily locate it later.
+        shutil.copy(args.config, Path(out_dir) / "download.yaml")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure download step copies config as `download.yaml`

## Testing
- `python -m py_compile src/pipeline/download.py src/utils/download_sentinel.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854e7d5dfa88320bd6c4afa5b663de5