### PR TITLE
Handle labels in each input directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ bash scripts/predict_sentinel2.sh
 ```
 `preprocess_sentinel2.sh` が出力する `features.npz` はダウンロードディレクトリ内の
 `preprocess/` サブフォルダに保存されます。利用したいフォルダを `configs/train.yaml` の
-`input_dirs` に列挙したうえで `train_model.sh` を実行してください。
+`input_dirs` に列挙したうえで `train_model.sh` を実行してください。各ディレクトリには
+対応するラベルファイル `labels.tif` も配置しておきます。
 
 
 

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -3,6 +3,7 @@ input_dirs:
   - data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31/preprocess
   # - path/to/another/preprocess_folder
 features: features.npz
-labels: data/raw/labels.tif
+# Label raster inside each input directory
+labels: labels.tif
 model_out: outputs/model.pkl
 n_estimators: 100


### PR DESCRIPTION
## Summary
- support labels.tif inside each training folder
- document that labels.tif must accompany every training directory

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6854f719fec08320bb304cab9e69963a