### PR TITLE
Update train config for labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ bash scripts/predict_sentinel2.sh
 `preprocess_sentinel2.sh` が出力する `features.npz` はダウンロードディレクトリ内の
 `preprocess/` サブフォルダに保存されます。利用したいフォルダを `configs/train.yaml` の
 `input_dirs` に列挙したうえで `train_model.sh` を実行してください。各ディレクトリには
-対応するラベルファイル `labels.tif` も配置しておきます。
+対応するラベルファイル `labels.tif` も配置しておきます。さらに
+`features: preprocess/features.npz` と `labels: labels.tif` のように
+ダウンロードフォルダからの相対パスを設定してください。
 
 
 

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,8 +1,8 @@
 # Training data directories containing the feature file listed below
 input_dirs:
-  - data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31/preprocess
-  # - path/to/another/preprocess_folder
-features: features.npz
+  - data/example_run/Sentinel-2/33.9160_130.7450_2024-01-01_2024-02-16
+  # - path/to/another/download_folder
+features: preprocess/features.npz
 # Label raster inside each input directory
 labels: labels.tif
 model_out: outputs/model.pkl

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -27,11 +27,11 @@ def main() -> None:
     label_arrays = []
 
     for d in input_dirs:
-        features_path = d / Path(cfg["features"]).name
+        features_path = d / cfg["features"]
         features = np.load(features_path)["features"]
         feature_arrays.append(features.reshape(features.shape[0], -1))
 
-        labels_path = d / Path(cfg["labels"]).name
+        labels_path = d / cfg["labels"]
         with rasterio.open(labels_path) as src:
             labels = src.read(1)
         label_arrays.append(labels.flatten())


### PR DESCRIPTION
## Summary
- update example `configs/train.yaml` to reference the download folder
- read feature/label paths relative to each download directory
- clarify README about relative paths in `train.yaml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6854fa79fedc8320ac47ae5ab1acfee6