### PR TITLE
Switch train config to model_name

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -5,5 +5,5 @@ input_dirs:
 features: preprocess/features.npz
 # Label raster inside each input directory
 labels: labels.tif
-model_out: outputs/model.pkl
+model_name: model.pkl
 n_estimators: 100

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -44,7 +44,7 @@ def main() -> None:
 
     clf = train_model(data, labels, n_estimators=cfg.get("n_estimators", 100))
 
-    model_path = output_dir / Path(cfg.get("model_out", "model.pkl")).name
+    model_path = output_dir / cfg.get("model_name", "model.pkl")
     model_path.parent.mkdir(parents=True, exist_ok=True)
     joblib.dump(clf, model_path)
 


### PR DESCRIPTION
## Summary
- change `model_out` to `model_name` in `configs/train.yaml`
- update `src/pipeline/train.py` to read the new config key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854ff806bec83209650f5aaec0dd3d8