### PR TITLE
Save preprocess config as features.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ bash scripts/train_model.sh
 bash scripts/predict_sentinel2.sh
 ```
 `preprocess_sentinel2.sh` が出力する `features.npz` はダウンロードディレクトリ内の
-`preprocess/` サブフォルダに保存されます。利用したいフォルダを `configs/train.yaml` の
-`input_dirs` に列挙したうえで `train_model.sh` を実行してください。各ディレクトリには
+`preprocess/` サブフォルダに保存されます。設定ファイルも同じフォルダに
+`features.yaml` の名前でコピーされるため、どの条件で特徴を算出したか後から確認できます。
+利用したいフォルダを `configs/train.yaml` の `input_dirs` に列挙したうえで `train_model.sh` を実行してください。各ディレクトリには
 対応するラベルファイル `labels.tif` も配置しておきます。さらに
 `features: preprocess/features.npz` と `labels: labels.tif` のように
 ダウンロードフォルダからの相対パスを設定してください。

--- a/src/pipeline/preprocess.py
+++ b/src/pipeline/preprocess.py
@@ -29,7 +29,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Preprocess Sentinel bands")
     parser.add_argument("--config", required=True, help="YAML config file")
     parser.add_argument("--input-dir", required=True, help="Directory with raw bands")
-    parser.add_argument("--output-dir", help="Directory for features")
+    parser.add_argument("--output-dir", help="Directory for dataset root")
     args = parser.parse_args()
 
     with open(args.config) as f:
@@ -37,9 +37,11 @@ def main() -> None:
 
     input_dir = Path(args.input_dir)
     if args.output_dir:
-        output_dir = Path(args.output_dir)
+        dataset_dir = Path(args.output_dir)
     else:
-        output_dir = input_dir / "preprocess"
+        dataset_dir = input_dir
+
+    output_dir = dataset_dir / "preprocess"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     dl_cfg_path = input_dir / "download.yaml"
@@ -85,7 +87,8 @@ def main() -> None:
     with open(out_path.with_suffix(".meta.json"), "w") as f:
         json.dump(meta_json, f)
 
-    shutil.copy(args.config, out_path.parent / Path(args.config).name)
+    config_copy_name = Path(cfg.get("features_out", "features.npz")).with_suffix(".yaml").name
+    shutil.copy(args.config, out_path.parent / config_copy_name)
     if dl_cfg_path.exists():
         shutil.copy(dl_cfg_path, out_path.parent / dl_cfg_path.name)
 


### PR DESCRIPTION
## Summary
- drop config copy into the `preprocess` subfolder with the same base name as the features file
- ensure preprocess results always land in a `preprocess` directory
- document the `features.yaml` copy in README

## Testing
- `python -m py_compile src/pipeline/preprocess.py`

------
https://chatgpt.com/codex/tasks/task_b_6855050fde84832098209e8e9aa3f2c3