### PR TITLE
Update pipeline paths and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,9 @@ bash scripts/predict_sentinel2.sh
 `features.yaml` の名前でコピーされるため、どの条件で特徴を算出したか後から確認できます。
 利用したいフォルダを `configs/train.yaml` の `input_dirs` に列挙したうえで `train_model.sh` を実行してください。各ディレクトリには
 対応するラベルファイル `labels.tif` も配置しておきます。さらに
-`features: preprocess/features.npz` と `labels: labels.tif` のように
-ダウンロードフォルダからの相対パスを設定してください。
+`features: features.npz` と `labels: labels.tif` のように
+ダウンロードフォルダからの相対パスを設定してください。特徴ファイルはスクリプト側で
+自動的に `preprocess/` サブフォルダを参照します。
 
 
 

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -1,4 +1,5 @@
-# The features file is expected inside the directory passed to `--features-dir`.
+# The features file is expected under the `preprocess` directory of
+# the directory provided to `--input-dir`.
 features: features.npz
-model: outputs/model.pkl
-output: outputs/prediction.tif
+# Path to the trained model relative to `--model-dir`.
+model: model.pkl

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -2,7 +2,9 @@
 input_dirs:
   - data/example_run/Sentinel-2/33.9160_130.7450_2024-01-01_2024-02-16
   # - path/to/another/download_folder
-features: preprocess/features.npz
+# Features are always stored under the `preprocess` directory of each
+# input folder. Only the file name is specified here.
+features: features.npz
 # Label raster inside each input directory
 labels: labels.tif
 model_name: model.pkl

--- a/scripts/predict_sentinel2.sh
+++ b/scripts/predict_sentinel2.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Hard coded paths for a single example run
-FEATURES_DIR="data/processed/example_run"
+INPUT_DIR="data/processed/example_run"
 MODEL_DIR="data/outputs/model_example"
 OUTPUT_DIR="data/outputs/prediction_example"
 CONFIG="configs/predict.yaml"
 
 python -m src.pipeline.predict --config "$CONFIG" \
-    --features-dir "$FEATURES_DIR" --model-dir "$MODEL_DIR" \
+    --input-dir "$INPUT_DIR" --model-dir "$MODEL_DIR" \
     --output-dir "$OUTPUT_DIR"
 

--- a/src/pipeline/predict.py
+++ b/src/pipeline/predict.py
@@ -13,7 +13,7 @@ from ..classification.predict import predict_model
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run model inference")
     parser.add_argument("--config", required=True, help="YAML config file")
-    parser.add_argument("--features-dir", required=True, help="Directory with features file")
+    parser.add_argument("--input-dir", required=True, help="Directory containing the dataset")
     parser.add_argument("--model-dir", required=True, help="Directory with trained model")
     parser.add_argument("--output-dir", required=True, help="Directory for prediction result")
     args = parser.parse_args()
@@ -21,18 +21,18 @@ def main() -> None:
     with open(args.config) as f:
         cfg = yaml.safe_load(f)
 
-    features_dir = Path(args.features_dir)
+    input_dir = Path(args.input_dir)
     model_dir = Path(args.model_dir)
     output_dir = Path(args.output_dir)
 
-    features_path = features_dir / Path(cfg["features"]).name
+    features_path = input_dir / "preprocess" / cfg["features"]
     data = np.load(features_path)["features"]
-    meta_path = features_dir / Path(cfg.get("meta", Path(cfg["features"]).with_suffix(".meta.json"))).name
+    meta_path = input_dir / "preprocess" / Path(cfg.get("meta", Path(cfg["features"]).with_suffix(".meta.json"))).name
     with open(meta_path) as f:
         meta = json.load(f)
 
-    clf = joblib.load(model_dir / Path(cfg["model"]).name)
-    out_path = output_dir / Path(cfg.get("output", "prediction.tif")).name
+    clf = joblib.load(model_dir / cfg["model"])
+    out_path = output_dir / "prediction.tif"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     predict_model(clf, data, meta, out_path)
 

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -27,7 +27,7 @@ def main() -> None:
     label_arrays = []
 
     for d in input_dirs:
-        features_path = d / cfg["features"]
+        features_path = d / "preprocess" / cfg["features"]
         features = np.load(features_path)["features"]
         feature_arrays.append(features.reshape(features.shape[0], -1))
 


### PR DESCRIPTION
## Summary
- simplify feature path in `train.yaml`
- remove output path from `predict.yaml` and update model filename
- adjust train and predict pipelines for hard-coded `preprocess` directory
- update helper script `predict_sentinel2.sh`
- clarify README about feature location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855095db8948320899d4b9258eebb18