### PR TITLE
Add optional name folder to pipeline download

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ NumPy arrays only.
 You can fetch sample imagery directly from the Copernicus Data Space using
 `src/utils/download_sentinel.py`. The script relies on **sentinelhub-py** and
 queries the `https://sh.dataspace.copernicus.eu` service. Downloads are cached
-under `data/raw/<OUTPUT>/<SATELLITE>/<lat_lon_dates>` based on location and time range. For the
+under `data/raw/<OUTPUT>/<NAME>/<SATELLITE>/<lat_lon_dates>` based on location and time range. The
+`<NAME>` directory is only created when the `--name` option is provided. For the
 example scripts this becomes `data/raw/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31`.
 The directory also contains a copy of `download.yaml` which later steps read to
 determine which bands were saved.

--- a/docs/sentinelhub_setup.md
+++ b/docs/sentinelhub_setup.md
@@ -17,8 +17,9 @@ Alternatively provide `--sh-base-url` and `--sh-token-url` when running
 `download_sentinel.py` or the pipeline downloader to override these endpoints
 without setting environment variables.
 
-Downloads are cached under `data/raw/<OUTPUT>/<SATELLITE>/<lat_lon_dates>` based on the selected
-location and date range. For instance the example scripts store files in
+Downloads are cached under `data/raw/<OUTPUT>/<NAME>/<SATELLITE>/<lat_lon_dates>` based on the selected
+location and date range. The additional `<NAME>` folder is only created when the `--name` option is
+given. For instance the example scripts store files in
 `data/raw/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31`. Each folder includes
 the original `download.yaml` which the preprocessing step reads back to locate
 the bands. Requests are sent to `https://sh.dataspace.copernicus.eu`. If the

--- a/src/pipeline/download.py
+++ b/src/pipeline/download.py
@@ -14,6 +14,10 @@ def main() -> None:
     parser.add_argument("--config", required=True, help="Path to YAML config")
     parser.add_argument("--output", required=True, help="Output directory")
     parser.add_argument(
+        "--name",
+        help="Optional subfolder name created under the output directory",
+    )
+    parser.add_argument(
         "--sh-base-url",
         default=SH_BASE_URL,
         type=str,
@@ -27,9 +31,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    base_dir = Path(args.output)
+    if args.name:
+        base_dir = base_dir / args.name
+
     out_dir = download_from_config(
         args.config,
-        args.output,
+        base_dir,
         sh_base_url=args.sh_base_url,
         sh_token_url=args.sh_token_url,
     )


### PR DESCRIPTION
## Summary
- allow pipeline download to create a named subdirectory via `--name`
- document new option in README and Sentinel Hub setup guide

## Testing
- `python -m compileall -q src remote_sensing`

------
https://chatgpt.com/codex/tasks/task_b_68550c93d4148320b9cff6537c19be63