### PR TITLE
Add name-based Sentinel output folder

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
             "module": "src.pipeline.cloud_removal",
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}",
-            "args": ["--input-dir","data/example_run/Sentinel-2/33.5890_130.2730_2024-01-01_2024-01-31"]
+            "args": ["--input-dir","data/example_run/Sentinel-2/hita"]
         },
         {
             "name": "Mosaic Data",
@@ -30,7 +30,7 @@
             "module": "src.pipeline.mosaic",
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}",
-            "args": ["--input-dir","data/example_run/Sentinel-2/33.5890_130.2730_2024-01-01_2024-01-31",
+            "args": ["--input-dir","data/example_run/Sentinel-2/hita",
                     "--method","best"]
         },
         {
@@ -41,7 +41,7 @@
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}",
             "args": ["--config","configs/preprocess.yaml",
-            "--input-dir","data/example_run/Sentinel-2/33.5890_130.2730_2024-01-01_2024-01-31"]
+            "--input-dir","data/example_run/Sentinel-2/hita"]
         },
         {
             "name": "download ESA WorldCover Country",
@@ -78,8 +78,8 @@
             "cwd": "${workspaceFolder}",
             "args": [
                 "--worldcover","data/wc2021_kyusyu_bbox",
-                //"--sentinel-dir","data/example_run/Sentinel-2/33.5890_130.2730_2024-01-01_2024-01-31"
-                "--sentinel-dir","data/example_run/Sentinel-2/33.9160_130.7450_2024-01-01_2024-02-16"
+                //"--sentinel-dir","data/example_run/Sentinel-2/hita"
+                "--sentinel-dir","data/example_run/Sentinel-2/karatzu"
             ]
         },
         {

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ WorldCover タイルから `labels.tif` を切り出すには
 ```bash
 python -m src.utils.worldcover_to_label \
   --worldcover data/wc2021_kyusyu_bbox \
-  --sentinel-dir data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31 \
-  --output data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31/labels.tif
+  --sentinel-dir data/example_run/Sentinel-2/hita \
+  --output data/example_run/Sentinel-2/hita/labels.tif
 ```
 
 #### WorldCover タイルだけを取得する
@@ -159,9 +159,9 @@ NumPy arrays only.
 You can fetch sample imagery directly from the Copernicus Data Space using
 `src/utils/download_sentinel.py`. The script relies on **sentinelhub-py** and
 queries the `https://sh.dataspace.copernicus.eu` service. Downloads are cached
-under `data/raw/<OUTPUT>/<NAME>/<SATELLITE>/<lat_lon_dates>` based on location and time range. The
-`<NAME>` directory is only created when the `--name` option is provided. For the
-example scripts this becomes `data/raw/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31`.
+under `data/raw/<OUTPUT>/<SATELLITE>/<FOLDER>` where `<FOLDER>` is either the
+automatically generated `<lat_lon_dates>` or the value passed to `--name`. For
+the example scripts this becomes `data/raw/example_run/Sentinel-2/hita`.
 The directory also contains a copy of `download.yaml` which later steps read to
 determine which bands were saved.
 

--- a/docs/sentinelhub_setup.md
+++ b/docs/sentinelhub_setup.md
@@ -17,10 +17,10 @@ Alternatively provide `--sh-base-url` and `--sh-token-url` when running
 `download_sentinel.py` or the pipeline downloader to override these endpoints
 without setting environment variables.
 
-Downloads are cached under `data/raw/<OUTPUT>/<NAME>/<SATELLITE>/<lat_lon_dates>` based on the selected
-location and date range. The additional `<NAME>` folder is only created when the `--name` option is
-given. For instance the example scripts store files in
-`data/raw/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31`. Each folder includes
+Downloads are cached under `data/raw/<OUTPUT>/<SATELLITE>/<FOLDER>` based on the selected
+location and date range. `<FOLDER>` is either the generated `<lat_lon_dates>` or the value
+supplied via `--name`. For instance the example scripts store files in
+`data/raw/example_run/Sentinel-2/hita`. Each folder includes
 the original `download.yaml` which the preprocessing step reads back to locate
 the bands. Requests are sent to `https://sh.dataspace.copernicus.eu`. If the
 directory already exists the cached files will be reused.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,9 +20,10 @@ source venv/bin/activate
 Downloads Sentinel imagery from the Copernicus Data Space using the
 `sentinelhub` service at `https://sh.dataspace.copernicus.eu`.
 The module resides under `src/utils/` and caches files inside
-`data/raw/<OUTPUT>/<SATELLITE>/<lat_lon_dates>` based on the selected location
-and date range. When using `scripts/download_sentinel2.sh` this resolves to
-`data/raw/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31`. The
+`data/raw/<OUTPUT>/<SATELLITE>/<FOLDER>` based on the selected location
+and date range. `<FOLDER>` defaults to `<lat_lon_dates>` but can be
+overridden with `--name`. When using `scripts/download_sentinel2.sh`
+this resolves to `data/raw/example_run/Sentinel-2/hita`. The
 generated folder also contains the used `download.yaml`, which
 `preprocess_sentinel2.sh` reads to find the downloaded bands. When
 run with a YAML configuration, the file is copied into the download directory for
@@ -91,5 +92,5 @@ present:
 ```bash
 python -m src.utils.worldcover_to_label \
   --worldcover data/wc2021_kyusyu_bbox \
-  --sentinel-dir data/example_run/Sentinel-2/35.6000_139.7000_2024-01-01_2024-01-31
+  --sentinel-dir data/example_run/Sentinel-2/hita
 ```

--- a/scripts/cloud_removal_sentinel2.sh
+++ b/scripts/cloud_removal_sentinel2.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 python -m src.pipeline.cloud_removal \
---input-dir "data/example_run/Sentinel-2/33.5890_130.2730_2024-01-01_2024-01-31"
+    --input-dir "data/example_run/Sentinel-2/hita"
 
 python -m src.pipeline.cloud_removal \
---input-dir "data/example_run/Sentinel-2/33.9160_130.7450_2024-01-01_2024-02-16"
+    --input-dir "data/example_run/Sentinel-2/karatzu"
 
 python -m src.pipeline.cloud_removal \
---input-dir "data/example_run/Sentinel-2/33.3800_131.4680_2024-01-01_2024-02-16"
+    --input-dir "data/example_run/Sentinel-2/aso"

--- a/scripts/create_labels_of_bbox.sh
+++ b/scripts/create_labels_of_bbox.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 python -m src.utils.worldcover_to_label --worldcover "data/wc2021_kyusyu_bbox" \
---sentinel-dir "data/example_run/Sentinel-2/33.5890_130.2730_2024-01-01_2024-01-31"
+    --sentinel-dir "data/example_run/Sentinel-2/hita"
 
 python -m src.utils.worldcover_to_label --worldcover "data/wc2021_kyusyu_bbox" \
---sentinel-dir "data/example_run/Sentinel-2/33.9160_130.7450_2024-01-01_2024-02-16"
+    --sentinel-dir "data/example_run/Sentinel-2/karatzu"
 
 python -m src.utils.worldcover_to_label --worldcover "data/wc2021_kyusyu_bbox" \
---sentinel-dir "data/example_run/Sentinel-2/33.3800_131.4680_2024-01-01_2024-02-16"
+    --sentinel-dir "data/example_run/Sentinel-2/aso"

--- a/scripts/mosaic_sentinel2.sh
+++ b/scripts/mosaic_sentinel2.sh
@@ -4,13 +4,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 python -m src.pipeline.mosaic \
---input-dir "data/example_run/Sentinel-2/33.5890_130.2730_2024-01-01_2024-01-31" \
+    --input-dir "data/example_run/Sentinel-2/hita" \
 --method best
 
 python -m src.pipeline.mosaic \
---input-dir "data/example_run/Sentinel-2/33.9160_130.7450_2024-01-01_2024-02-16" \
+    --input-dir "data/example_run/Sentinel-2/karatzu" \
 --method best
 
 python -m src.pipeline.mosaic \
---input-dir "data/example_run/Sentinel-2/33.3800_131.4680_2024-01-01_2024-02-16" \
+    --input-dir "data/example_run/Sentinel-2/aso" \
 --method best

--- a/scripts/preprocess_sentinel2.sh
+++ b/scripts/preprocess_sentinel2.sh
@@ -7,10 +7,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG="configs/preprocess.yaml"  # features_out path; band names loaded from download.yaml
 
 python -m src.pipeline.preprocess --config "$CONFIG" \
---input-dir "data/example_run/Sentinel-2/33.5890_130.2730_2024-01-01_2024-01-31" \
+    --input-dir "data/example_run/Sentinel-2/hita" \
 
 python -m src.pipeline.preprocess --config "$CONFIG" \
---input-dir "data/example_run/Sentinel-2/33.9160_130.7450_2024-01-01_2024-02-16" \
+    --input-dir "data/example_run/Sentinel-2/karatzu" \
 
 python -m src.pipeline.preprocess --config "$CONFIG" \
---input-dir "data/example_run/Sentinel-2/33.3800_131.4680_2024-01-01_2024-02-16" \
+    --input-dir "data/example_run/Sentinel-2/aso" \

--- a/src/pipeline/download.py
+++ b/src/pipeline/download.py
@@ -15,7 +15,7 @@ def main() -> None:
     parser.add_argument("--output", required=True, help="Output directory")
     parser.add_argument(
         "--name",
-        help="Optional subfolder name created under the output directory",
+        help="Optional folder name placed under the satellite directory",
     )
     parser.add_argument(
         "--sh-base-url",
@@ -32,14 +32,13 @@ def main() -> None:
     args = parser.parse_args()
 
     base_dir = Path(args.output)
-    if args.name:
-        base_dir = base_dir / args.name
 
     out_dir = download_from_config(
         args.config,
         base_dir,
         sh_base_url=args.sh_base_url,
         sh_token_url=args.sh_token_url,
+        name=args.name,
     )
     # Later pipeline stages expect the config file to be named
     # ``download.yaml`` inside the download directory.


### PR DESCRIPTION
## Summary
- support custom folder names under the Sentinel directory via `--name`
- update docs and example scripts to reflect new layout `data/.../Sentinel-2/<NAME>`
- adjust VS Code launch config paths

## Testing
- `python -m py_compile src/utils/download_sentinel.py src/pipeline/download.py`

------
https://chatgpt.com/codex/tasks/task_b_6855100a147083208932312ea777ec6b