### PR TITLE
Add RF sampling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ bash scripts/predict_sentinel2.sh
 ダウンロードフォルダからの相対パスを設定してください。特徴ファイルはスクリプト側で
 自動的に `preprocess/` サブフォルダを参照します。
 
+`configs/train.yaml` では `n_estimators` のほか `max_depth` や `max_samples`
+を設定できます。大量のピクセルから一部のみ学習したい場合は
+`sample_fraction` に 0〜1 の値を指定してください。
+
 
 
 ## Running the pipeline

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -10,3 +10,9 @@ features: features.npz
 labels: labels.tif
 model_name: model.pkl
 n_estimators: 100
+# Optional RandomForest parameters
+# max_depth: null   # e.g. 10
+# max_samples: null # e.g. 0.5 to use half the pixels per tree
+
+# Fraction of all pixels to randomly sample before training
+# sample_fraction: null  # e.g. 0.1 for 10%

--- a/src/classification/train_model.py
+++ b/src/classification/train_model.py
@@ -2,13 +2,42 @@ import numpy as np
 from sklearn.ensemble import RandomForestClassifier
 
 
-def train_model(features, labels, n_estimators=100, random_state=0):
-    """Train a RandomForest model."""
+def train_model(
+    features,
+    labels,
+    n_estimators=100,
+    random_state=0,
+    max_depth=None,
+    max_samples=None,
+):
+    """Train a RandomForest model.
+
+    Parameters
+    ----------
+    features : np.ndarray
+        Array of features with shape ``(bands, n_samples)`` or
+        ``(bands, height, width)``.
+    labels : np.ndarray
+        Corresponding label raster or array.
+    n_estimators : int, optional
+        Number of trees in the forest.
+    random_state : int, optional
+        Seed for the ``RandomForestClassifier``.
+    max_depth : int or None, optional
+        Maximum depth of the trees.
+    max_samples : int, float or None, optional
+        Number or fraction of samples to draw for training each tree.
+    """
     X = features.reshape(features.shape[0], -1).T
     y = labels.flatten()
     mask = ~np.isnan(X).any(axis=1)
     X = X[mask]
     y = y[mask]
-    clf = RandomForestClassifier(n_estimators=n_estimators, random_state=random_state)
+    clf = RandomForestClassifier(
+        n_estimators=n_estimators,
+        random_state=random_state,
+        max_depth=max_depth,
+        max_samples=max_samples,
+    )
     clf.fit(X, y)
     return clf

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -42,7 +42,22 @@ def main() -> None:
     data = np.hstack(feature_arrays)
     labels = np.hstack(label_arrays)
 
-    clf = train_model(data, labels, n_estimators=cfg.get("n_estimators", 100))
+    sample_fraction = cfg.get("sample_fraction")
+    if sample_fraction:
+        n_samples = data.shape[1]
+        size = int(n_samples * sample_fraction)
+        rng = np.random.default_rng(0)
+        idx = rng.choice(n_samples, size=size, replace=False)
+        data = data[:, idx]
+        labels = labels[idx]
+
+    clf = train_model(
+        data,
+        labels,
+        n_estimators=cfg.get("n_estimators", 100),
+        max_depth=cfg.get("max_depth"),
+        max_samples=cfg.get("max_samples"),
+    )
 
     model_path = output_dir / cfg.get("model_name", "model.pkl")
     model_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- expose `max_depth` and `max_samples` on `train_model`
- allow optional dataset sampling in `train.py`
- document new options in `train.yaml` and README

## Testing
- `python -m compileall -q src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685a052a9d288320b49a2b629dd025e3