### PR TITLE
Add training progress flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ bash scripts/predict_sentinel2.sh
 `configs/train.yaml` では `n_estimators` のほか `max_depth` や `max_samples`
 を設定できます。大量のピクセルから一部のみ学習したい場合は
 `sample_fraction` に 0〜1 の値を指定してください。
+学習の進捗を表示したい場合は `VERBOSE=1 bash scripts/train_model.sh` のように
+環境変数 `VERBOSE` を設定してください。
 
 
 

--- a/scripts/train_model.sh
+++ b/scripts/train_model.sh
@@ -10,5 +10,6 @@ CONFIG="configs/train.yaml"
 # The training script reads feature directories from $CONFIG
 
 python -m src.pipeline.train --config "$CONFIG" \
-    --output-dir "$OUTPUT_DIR"
+    --output-dir "$OUTPUT_DIR" \
+    --verbose "${VERBOSE:-0}"
 

--- a/src/classification/train_model.py
+++ b/src/classification/train_model.py
@@ -9,6 +9,7 @@ def train_model(
     random_state=0,
     max_depth=None,
     max_samples=None,
+    verbose=0,
 ):
     """Train a RandomForest model.
 
@@ -27,6 +28,8 @@ def train_model(
         Maximum depth of the trees.
     max_samples : int, float or None, optional
         Number or fraction of samples to draw for training each tree.
+    verbose : int, optional
+        Verbosity level for ``RandomForestClassifier``.
     """
     X = features.reshape(features.shape[0], -1).T
     y = labels.flatten()
@@ -38,6 +41,7 @@ def train_model(
         random_state=random_state,
         max_depth=max_depth,
         max_samples=max_samples,
+        verbose=verbose,
     )
     clf.fit(X, y)
     return clf

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -14,6 +14,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Train classification model")
     parser.add_argument("--config", required=True, help="YAML config file")
     parser.add_argument("--output-dir", required=True, help="Directory for model")
+    parser.add_argument(
+        "--verbose",
+        type=int,
+        default=0,
+        help="Verbosity level for RandomForest training",
+    )
     args = parser.parse_args()
 
     with open(args.config) as f:
@@ -57,6 +63,7 @@ def main() -> None:
         n_estimators=cfg.get("n_estimators", 100),
         max_depth=cfg.get("max_depth"),
         max_samples=cfg.get("max_samples"),
+        verbose=args.verbose,
     )
 
     model_path = output_dir / cfg.get("model_name", "model.pkl")


### PR DESCRIPTION
## Summary
- support verbosity in `train_model`
- expose `--verbose` CLI option for training
- allow setting VERBOSE in `train_model.sh`
- document progress flag in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866697e0a4083209d916294a5bb1533