### PR TITLE
Highlight difference raster mismatches

### DIFF
--- a/docs/evaluation_metrics.md
+++ b/docs/evaluation_metrics.md
@@ -1,0 +1,61 @@
+# Land Cover Classification Evaluation Metrics
+
+Remote sensing land cover classification models are commonly evaluated with categorical metrics derived from comparisons between model predictions and ground-truth labels (e.g., GT GeoTIFFs).
+
+## Recommended Core Metrics
+
+多クラス土地被覆分類の実務評価では、以下の組み合わせを用いるのが一般的です。
+
+1. **混同行列** – まず全クラスの混同行列を作成し、誤分類の傾向を把握します。
+2. **全体精度 (Overall Accuracy)** – 全体の達成度を一目で把握する指標として併記します。
+3. **クラス別のプロデューサズ精度 (PA) とユーザーズ精度 (UA)** – 欠落誤差・過剰誤差を定量化し、どのクラスが課題かを診断します。
+4. **F1 スコア（マクロ平均）** または **IoU / mIoU** – クラス不均衡に強い代表的な統合指標として、多クラス平均値を報告します。ピクセル単位のセマンティックセグメンテーションでは mIoU がよく採用されます。
+
+このセットをベースに、必要に応じて下記の補助指標を追加すると、報告内容に厚みが出ます。
+
+## Confusion Matrix
+- **Definition:** A contingency table that compares predicted classes versus ground-truth classes for every pixel.
+- **Use:** Serves as the basis for most other metrics and allows visual inspection of systematic confusion between classes.
+
+## Overall Accuracy (OA)
+- **Definition:** The proportion of correctly classified pixels across all classes.
+- **Interpretation:** Easy to understand but can be dominated by large or majority classes.
+
+## Producer's Accuracy and User's Accuracy
+- **Producer's Accuracy (PA):** For a given class, PA = correctly predicted pixels of that class / total ground-truth pixels of that class. It measures omission errors (how often true class pixels are missed).
+- **User's Accuracy (UA):** For a given class, UA = correctly predicted pixels of that class / total predicted pixels of that class. It measures commission errors (how often predicted class pixels are incorrect).
+
+### Visualizing differences between `prediction.tif` and `labels.tif`
+
+- **Difference highlight (`difference.tif`):** The pipeline exports a binary mismatch layer in which 0 means prediction and label agree, 1 highlights class mismatches, and 255 remains nodata. A red colormap is embedded so loading the TIFF in a GIS reveals mismatched pixels as a bright overlay on top of the base map. `metrics.json` 保存の `difference_summary` には評価対象ピクセル数・ミスマッチ数・ミスマッチ率が入っており、数値でも確認できます。
+- **Use UA when overestimation matters:** UA drops when many predicted pixels for a class are false positives, so it is the better scalar indicator of "over-mapping" a class relative to the ground truth.
+- **Use PA when underestimation matters:** PA decreases when ground-truth pixels are missed (false negatives), making it the preferred metric when you care about areas where the model fails to map existing class extents.
+- **Pair the map with PA/UA:** The highlight layer shows *where* discrepancies occur, while UA pinpoints classes responsible for commission errors and PA highlights classes suffering omission errors. Reviewing both gives a balanced explanation for the spatial patterns in the difference layer.
+
+## F1 Score
+- **Definition:** Harmonic mean of precision (UA) and recall (PA) per class, i.e., F1 = 2 × (Precision × Recall) / (Precision + Recall).
+- **Variants:** Macro-averaged F1 treats each class equally, while weighted F1 scales by class prevalence.
+
+## Intersection over Union (IoU)
+- **Definition:** IoU = True Positives / (True Positives + False Positives + False Negatives) for each class.
+- **Mean IoU (mIoU):** Average IoU across classes; robust to class imbalance compared to OA.
+
+## Cohen's Kappa Coefficient
+- **Definition:** Measures agreement between predictions and ground truth after accounting for agreement expected by chance.
+- **Interpretation:** Useful when class imbalance is present; values range from -1 (complete disagreement) to 1 (perfect agreement).
+
+## Balanced Accuracy
+- **Definition:** Average of per-class recall (PA). Equivalent to the mean of the diagonal of the normalized confusion matrix by ground-truth counts.
+- **Use:** Mitigates bias towards majority classes.
+
+## Area-Adjusted Accuracy Metrics
+- **Context:** When validation data come from stratified sampling, accuracy estimates can be adjusted to account for unequal area representation per class, providing unbiased regional accuracy estimates.
+
+## Spatially Aware Metrics (Optional)
+- **Examples:** Boundary F1 scores, structural similarity, or clump-based accuracies that consider neighborhood coherence.
+- **Use:** Helpful when map smoothness or spatial patterns are critical, though they are more complex to compute.
+
+## Practical Considerations
+- **Cross-Validation:** Split labeled data spatially to avoid spatial autocorrelation bias when estimating metrics.
+- **Confidence Intervals:** Bootstrap resampling over tiles or polygons provides uncertainty ranges for reported metrics.
+

--- a/src/pipeline/predict.py
+++ b/src/pipeline/predict.py
@@ -3,8 +3,10 @@ import json
 import joblib
 import shutil
 from pathlib import Path
+from typing import Dict, Optional, Tuple
 
 import numpy as np
+import rasterio
 import yaml
 
 from ..classification.predict import predict_model
@@ -12,6 +14,116 @@ from ..preprocess.cloudmask import cloud_mask
 from ..preprocess.stack_bands import stack_bands
 from ..preprocess.features import compute_features
 from .preprocess import split_band_stack
+from ..utils.io_raster import write_raster
+
+
+_DIFFERENCE_HIGHLIGHT_COLORMAP: Dict[int, Dict[int, Tuple[int, int, int, int]]] = {
+    1: {
+        0: (0, 0, 0, 0),        # transparent for matching pixels
+        1: (255, 0, 0, 255),    # red highlight for mismatches
+    }
+}
+
+
+def _safe_divide(numerator: float, denominator: float) -> Optional[float]:
+    if denominator == 0:
+        return None
+    return float(numerator) / float(denominator)
+
+
+def _compute_core_metrics(
+    predictions: np.ndarray, labels: np.ndarray
+) -> Optional[Dict[str, object]]:
+    # Treat label value 0 as background / nodata and exclude it from evaluation.
+    valid_mask = labels > 0
+    if not np.any(valid_mask):
+        return None
+
+    pred_flat = predictions[valid_mask].ravel()
+    label_flat = labels[valid_mask].ravel()
+
+    positive_labels = {int(c) for c in np.unique(label_flat) if c > 0}
+    positive_preds = {int(c) for c in np.unique(pred_flat) if c > 0}
+    class_id_set = positive_labels | positive_preds
+    has_unclassified = np.any(pred_flat <= 0)
+    if has_unclassified:
+        class_id_set.add(0)
+
+    if not class_id_set:
+        return None
+
+    class_ids = sorted(class_id_set)
+    class_to_index = {cls: idx for idx, cls in enumerate(class_ids)}
+    matrix = np.zeros((len(class_ids), len(class_ids)), dtype=int)
+
+    for true_val, pred_val in zip(label_flat, pred_flat):
+        true_cls = int(true_val)
+        if true_cls <= 0:
+            continue
+        pred_cls = int(pred_val) if int(pred_val) > 0 else 0 if has_unclassified else int(pred_val)
+        matrix[class_to_index[true_cls], class_to_index[pred_cls]] += 1
+
+    totals = label_flat.size
+    if totals == 0:
+        return None
+
+    diagonal = np.diag(matrix)
+    row_sums = matrix.sum(axis=1)
+    col_sums = matrix.sum(axis=0)
+
+    producer_accuracy: Dict[str, Optional[float]] = {}
+    user_accuracy: Dict[str, Optional[float]] = {}
+    f1_per_class: Dict[str, Optional[float]] = {}
+
+    eval_indices = [i for i, cls in enumerate(class_ids) if cls > 0]
+
+    for idx in eval_indices:
+        cls = class_ids[idx]
+        recall = _safe_divide(diagonal[idx], row_sums[idx])
+        precision = _safe_divide(diagonal[idx], col_sums[idx])
+
+        producer_accuracy[str(cls)] = recall
+        user_accuracy[str(cls)] = precision
+
+        if recall is None or precision is None:
+            f1_per_class[str(cls)] = None
+        elif recall == 0 and precision == 0:
+            f1_per_class[str(cls)] = 0.0
+        else:
+            f1_per_class[str(cls)] = 2 * precision * recall / (precision + recall)
+
+    f1_values = [v for v in f1_per_class.values() if v is not None]
+    macro_f1 = _safe_divide(sum(f1_values), len(f1_values)) if f1_values else None
+
+    correct = sum(int(diagonal[idx]) for idx in eval_indices)
+    overall_accuracy = _safe_divide(correct, totals)
+
+    producer_accuracy = {
+        cls: (float(val) if val is not None else None)
+        for cls, val in producer_accuracy.items()
+    }
+    user_accuracy = {
+        cls: (float(val) if val is not None else None)
+        for cls, val in user_accuracy.items()
+    }
+    f1_per_class = {
+        cls: (float(val) if val is not None else None)
+        for cls, val in f1_per_class.items()
+    }
+
+    classes = [int(cls) for cls in class_ids]
+    overall_accuracy = overall_accuracy if overall_accuracy is None else float(overall_accuracy)
+    macro_f1 = macro_f1 if macro_f1 is None else float(macro_f1)
+
+    return {
+        "classes": classes,
+        "confusion_matrix": matrix.tolist(),
+        "overall_accuracy": overall_accuracy,
+        "producer_accuracy": producer_accuracy,
+        "user_accuracy": user_accuracy,
+        "f1_per_class": f1_per_class,
+        "macro_f1": macro_f1,
+    }
 
 
 def main() -> None:
@@ -55,7 +167,11 @@ def main() -> None:
             bands = [input_dir / f"{b}.tif" for b in spectral]
             scl_path = input_dir / "SCL.tif" if "SCL" in dl_cfg.get("bands", []) else input_dir / Path(cfg["scl"]).name
             mask_path = (
-                input_dir / "MASK.tif" if "dataMask" in dl_cfg.get("bands", []) else input_dir / Path(cfg.get("mask", "")).name if cfg.get("mask") else None
+                input_dir / "MASK.tif"
+                if "dataMask" in dl_cfg.get("bands", [])
+                else input_dir / Path(cfg.get("mask", "")).name
+                if cfg.get("mask")
+                else None
             )
         else:
             bands = [input_dir / Path(p).name for p in cfg["bands"]]
@@ -69,7 +185,59 @@ def main() -> None:
     clf = joblib.load(model_dir / cfg["model"])
     out_path = output_dir / "prediction.tif"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    predict_model(clf, data, meta, out_path)
+    predictions = predict_model(clf, data, meta, out_path)
+
+    labels_path = input_dir / cfg.get("labels", "labels.tif")
+    if labels_path.exists():
+        with rasterio.open(labels_path) as src:
+            labels = src.read(1)
+
+        if labels.shape != predictions.shape:
+            raise ValueError(
+                "Shape mismatch between predictions and labels: "
+                f"{predictions.shape} vs {labels.shape}"
+            )
+
+        metrics = _compute_core_metrics(predictions, labels)
+
+        # Export a binary mismatch highlight layer for visual inspection.
+        difference_path = out_path.parent / "difference.tif"
+        highlight = np.full(predictions.shape, 255, dtype=np.uint8)
+        valid_diff_mask = labels > 0
+        if np.any(valid_diff_mask):
+            label_vals = labels[valid_diff_mask].astype(np.int32)
+            pred_vals = predictions[valid_diff_mask].astype(np.int32)
+            mismatch_mask = pred_vals != label_vals
+
+            highlight[valid_diff_mask] = mismatch_mask.astype(np.uint8)
+
+            diff_meta = meta.copy()
+            diff_meta.update(count=1, dtype="uint8", nodata=255)
+            write_raster(
+                difference_path,
+                highlight[np.newaxis, ...],
+                diff_meta,
+                colormap=_DIFFERENCE_HIGHLIGHT_COLORMAP,
+            )
+
+            if metrics is not None:
+                total_pixels = int(mismatch_mask.size)
+                mismatch_pixels = int(mismatch_mask.sum())
+                metrics["difference_summary"] = {
+                    "mismatch_pixels": mismatch_pixels,
+                    "evaluated_pixels": total_pixels,
+                    "mismatch_rate": _safe_divide(mismatch_pixels, total_pixels),
+                    "values": {
+                        "match": 0,
+                        "mismatch": 1,
+                        "nodata": 255,
+                    },
+                }
+
+        if metrics is not None:
+            metrics_path = out_path.parent / "metrics.json"
+            with open(metrics_path, "w", encoding="utf-8") as f:
+                json.dump(metrics, f, indent=2, ensure_ascii=False)
 
     shutil.copy(args.config, out_path.parent / Path(args.config).name)
 

--- a/src/utils/io_raster.py
+++ b/src/utils/io_raster.py
@@ -1,7 +1,17 @@
+from typing import Mapping, Optional, Tuple
+
 import rasterio
 
 
-def write_raster(path, array, meta):
+def write_raster(
+    path,
+    array,
+    meta,
+    colormap: Optional[Mapping[int, Mapping[int, Tuple[int, int, int, int]]]] = None,
+):
     """Write a raster array to disk."""
     with rasterio.open(path, 'w', **meta) as dst:
         dst.write(array)
+        if colormap:
+            for band, cmap in colormap.items():
+                dst.write_colormap(band, dict(cmap))


### PR DESCRIPTION
## Summary
- replace the previous difference heatmap with a binary mismatch highlight layer so GIS tools clearly show disagreement pixels
- update the exported metrics summary to report mismatch counts and document the highlight values
- refresh the evaluation guide to explain the new overlay behaviour alongside PA/UA interpretation

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68e36a450ce88320b94afe6b48ccae9d